### PR TITLE
Fix lint errors and warnings + add lint step to pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,9 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,md}": [
-      "prettier --write"
+    "*.{ts,js,css,md}": [
+      "prettier --write",
+      "ng lint ngx-openmrs-formentry"
     ]
   }
 }

--- a/projects/ngx-formentry/src/components/select/select.component.ts
+++ b/projects/ngx-formentry/src/components/select/select.component.ts
@@ -19,6 +19,7 @@ import { OptionList } from './option-list';
 
 export const SELECT_VALUE_ACCESSOR: ExistingProvider = {
   provide: NG_VALUE_ACCESSOR,
+  // tslint:disable:no-use-before-declare
   useExisting: forwardRef(() => SelectComponent),
   multi: true
 };

--- a/projects/ngx-formentry/src/encounter-viewer/encounter-viewer.module.ts
+++ b/projects/ngx-formentry/src/encounter-viewer/encounter-viewer.module.ts
@@ -8,7 +8,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { QuestionControlComponent } from './display-controls/question-control.component';
 import { FilePreviewComponent } from './display-controls/file-preview.component';
 import { RemoteAnswerComponent } from './display-controls/remote-answer.component';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from '../shared.module';
 @NgModule({
   declarations: [
@@ -22,10 +22,10 @@ import { SharedModule } from '../shared.module';
     FormsModule,
     ReactiveFormsModule,
     CommonModule,
-    HttpModule,
+    HttpClientModule,
     SharedModule
   ],
   providers: [EncounterViewerService, EncounterPdfViewerService],
-  exports: [EncounterContainerComponent, HttpModule]
+  exports: [EncounterContainerComponent, HttpClientModule]
 })
 export class EncounterViewerModule {}

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -135,8 +135,8 @@ export class FormRendererComponent implements OnInit {
   checkSection(node: NodeBase) {
     if (node.question.renderingType === 'section') {
       let groupChildrenHidden = false;
-      let allSectionControlsHidden = Object.keys(node.children).every((k) => {
-        let innerNode = node.children[k];
+      const allSectionControlsHidden = Object.keys(node.children).every((k) => {
+        const innerNode = node.children[k];
         if (innerNode instanceof GroupNode) {
           groupChildrenHidden = Object.keys(innerNode.children).every(
             (i) => innerNode.children[i].control.hidden

--- a/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
+++ b/projects/ngx-formentry/src/form-entry/value-adapters/encounter.adapter.ts
@@ -55,7 +55,7 @@ export class EncounterAdapter implements ValueAdapter {
             const firstProvider: any =
               payload['encounterProviders'][0].provider;
             if (firstProvider && firstProvider.uuid) {
-              //Very weird work around for an issue with setting the value
+              // Very weird work around for an issue with setting the value
               node.control.setValue(firstProvider.uuid);
               setTimeout(() => {
                 node.control.setValue(firstProvider.uuid);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+
 import { Http, ResponseContentType, Headers } from '@angular/http';
 import { Subscriber } from 'rxjs';
 
@@ -26,7 +28,7 @@ const formOrdersPayload = require('./mock/orders.json');
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   data: any;
   schema: any;
   sections: {} = {};
@@ -36,7 +38,7 @@ export class AppComponent {
   stack = [];
   encounterObject = adultFormObs;
   showingEncounterViewer = false;
-  public header: string = 'UMD Demo';
+  public header = 'UMD Demo';
 
   constructor(
     private questionFactory: QuestionFactory,
@@ -47,7 +49,7 @@ export class AppComponent {
     private dataSources: DataSources,
     private encounterPdfViewerService: EncounterPdfViewerService,
     private formErrorsService: FormErrorsService,
-    private http: Http
+    private http: HttpClient
   ) {
     this.schema = adultForm;
   }
@@ -74,11 +76,11 @@ export class AppComponent {
       resolveSelectedValue: this.sampleResolve
     });
 
-    let ds = {
+    const ds = {
       dataSourceOptions: { concept: undefined },
       searchOptions: (text?: string) => {
         if (ds.dataSourceOptions && ds.dataSourceOptions.concept) {
-          let items: Array<any> = [
+          const items: Array<any> = [
             { id: 1, text: 'Stage 1 Symptom' },
             { id: 2, text: 'Stage 2 Symptom' }
           ];
@@ -92,7 +94,7 @@ export class AppComponent {
 
       resolveSelectedValue: (key: string) => {
         if (ds.dataSourceOptions && ds.dataSourceOptions.concept) {
-          let item = { id: 1, text: 'Stage 1 Symptom' };
+          const item = { id: 1, text: 'Stage 1 Symptom' };
           return Observable.create((observer: Subject<any>) => {
             setTimeout(() => {
               observer.next(item);
@@ -104,7 +106,7 @@ export class AppComponent {
 
     this.dataSources.registerDataSource('conceptAnswers', ds);
 
-    let obs = new MockObs();
+    const obs = new MockObs();
     this.dataSources.registerDataSource('rawPrevEnc', obs.getObs());
 
     this.dataSources.registerDataSource('patient', { sex: 'M' }, true);
@@ -125,16 +127,17 @@ export class AppComponent {
         console.log(url, 'APP COMPONENT');
         return new Observable((observer: Subscriber<any>) => {
           let objectUrl: string = null;
-          const headers = new Headers({
+          const headers = new HttpHeaders({
             Accept: 'image/png,image/jpeg,image/gif,application/pdf'
           });
           this.http
             .get('https://unsplash.it/1040/720', {
               headers,
-              responseType: ResponseContentType.Blob
+              responseType: 'json'
             })
-            .subscribe((m) => {
-              objectUrl = URL.createObjectURL(m.blob());
+            .subscribe((res: any) => {
+              const blob = new Blob(res.body);
+              objectUrl = URL.createObjectURL(blob);
               console.log(objectUrl);
               observer.next(objectUrl);
             });
@@ -167,11 +170,13 @@ export class AppComponent {
   }
 
   public setUpCascadeSelectForWHOStaging() {
-    let subject = new Subject();
-    let source = this.dataSources.dataSources['conceptAnswers'];
+    const subject = new Subject();
+    const source = this.dataSources.dataSources['conceptAnswers'];
     source.dataFromSourceChanged = subject.asObservable();
 
-    let whoStageQuestion = this.form.searchNodeByQuestionId('adultWHOStage')[0];
+    const whoStageQuestion = this.form.searchNodeByQuestionId(
+      'adultWHOStage'
+    )[0];
     if (whoStageQuestion) {
       whoStageQuestion.control.valueChanges.subscribe((val) => {
         if (source.dataFromSourceChanged) {
@@ -210,7 +215,7 @@ export class AppComponent {
   }
 
   public sampleResolve(): Observable<any> {
-    let item = { value: '1', label: 'Art3mis' };
+    const item = { value: '1', label: 'Art3mis' };
     return Observable.create((observer: Subject<any>) => {
       setTimeout(() => {
         observer.next(item);
@@ -219,7 +224,7 @@ export class AppComponent {
   }
 
   public sampleSearch(): Observable<any> {
-    let items: Array<any> = [
+    const items: Array<any> = [
       { value: '0', label: 'Aech' },
       { value: '5b6e58ea-1359-11df-a1f1-0026b9348838', label: 'Art3mis' },
       { value: '2', label: 'Daito' },
@@ -250,7 +255,7 @@ export class AppComponent {
 
     if (this.form.valid) {
       this.form.showErrors = false;
-      let payload = this.encAdapter.generateFormPayload(this.form);
+      const payload = this.encAdapter.generateFormPayload(this.form);
       console.log('encounter payload', payload);
 
       // Alternative is to populate for each as shown below

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { FormGroup } from '@angular/forms';
 
-import { Http, ResponseContentType, Headers } from '@angular/http';
 import { Subscriber } from 'rxjs';
+import { Observable, Subject, of } from 'rxjs';
 
 import {
   QuestionFactory,
@@ -15,9 +16,6 @@ import {
   FormErrorsService,
   EncounterPdfViewerService
 } from '../../dist/ngx-formentry';
-import { FormGroup } from '@angular/forms';
-import { Observable, Subject, of } from 'rxjs';
-
 import { MockObs } from './mock/mock-obs';
 
 const adultForm = require('./adult-1.4.json');
@@ -124,7 +122,6 @@ export class AppComponent implements OnInit {
         return of({ image: 'https://unsplash.it/1040/720' });
       },
       fetchFile: (url) => {
-        console.log(url, 'APP COMPONENT');
         return new Observable((observer: Subscriber<any>) => {
           let objectUrl: string = null;
           const headers = new HttpHeaders({
@@ -138,7 +135,6 @@ export class AppComponent implements OnInit {
             .subscribe((res: any) => {
               const blob = new Blob(res.body);
               objectUrl = URL.createObjectURL(blob);
-              console.log(objectUrl);
               observer.next(objectUrl);
             });
 
@@ -180,7 +176,6 @@ export class AppComponent implements OnInit {
     if (whoStageQuestion) {
       whoStageQuestion.control.valueChanges.subscribe((val) => {
         if (source.dataFromSourceChanged) {
-          console.log('changing value for WHO', val);
           if (val === 'a89b2606-1350-11df-a1f1-0026b9348838') {
             subject.next([
               { value: 3, label: 'Stage 3 Symptom' },
@@ -256,16 +251,13 @@ export class AppComponent implements OnInit {
     if (this.form.valid) {
       this.form.showErrors = false;
       const payload = this.encAdapter.generateFormPayload(this.form);
-      console.log('encounter payload', payload);
 
       // Alternative is to populate for each as shown below
       // // generate obs payload
       // let payload = this.obsValueAdapater.generateFormPayload(this.form);
-      // console.log('obs payload', payload);
 
       // // generate orders payload
       // let ordersPayload = this.orderAdaptor.generateFormPayload(this.form);
-      // console.log('orders Payload', ordersPayload);
     } else {
       this.form.showErrors = true;
       this.form.markInvalidControls(this.form.rootNode);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
+import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
-import { NgModule } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormEntryModule } from '../../dist/ngx-formentry';
 
@@ -12,6 +13,7 @@ import { AppComponent } from './app.component';
     BrowserModule,
     BrowserAnimationsModule,
     FormEntryModule,
+    HttpClientModule,
     ReactiveFormsModule
   ],
   providers: [],


### PR DESCRIPTION
This PR:

- Fixes lint warnings and errors from running `ng lint`. Some of these are due to using [HttpModule](https://v6.angular.io/api/http/Http), an API that was deprecated in favor of [HttpClientModule](https://angular.io/api/common/http/HttpClient).
- Adds `ng lint ngx-openmrs-formentry` to the pre-commit hook so that the project runs `tslint` against the project locally pre-commit.
- Swaps out some `let` variable declarations to use `const` per the tslint `prefer-const` rule.