### PR TITLE
Point travis status badge to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/AMPATH/ngx-openmrs-formentry.svg?branch=master)](https://travis-ci.org/AMPATH/ngx-openmrs-formentry)
+[![Build Status](https://travis-ci.com/AMPATH/ngx-openmrs-formentry.svg?branch=master)](https://travis-ci.com/AMPATH/ngx-openmrs-formentry)
 
 # AMPATH POC Formentry
 


### PR DESCRIPTION
Points Travis status badge URL to new CI link following migration from `travis.org` to `travis.com`.