### PR TITLE
Add helper function for computing bsa given height and weight

### DIFF
--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.spec.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.spec.ts
@@ -24,6 +24,21 @@ describe('JS Expression Helper Service:', () => {
     expect(bmi).toBe(21.6);
   });
 
+  it('should compute the correct bsa value when height and weight are provided', () => {
+    const helper: JsExpressionHelper = TestBed.get(JsExpressionHelper);
+
+    let bsa, height, weight;
+
+    bsa = helper.calcBSA(height, weight);
+    expect(bsa).toBeNull();
+
+    height = 190.5; // cm
+    weight = 95; // kg
+
+    bsa = helper.calcBSA(height, weight);
+    expect(bsa).toBe(2.24);
+  });
+
   it('should return true if value is empty, null or undefined', () => {
     const helper: JsExpressionHelper = TestBed.get(JsExpressionHelper);
     let val = '';

--- a/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/js-expression-helper.ts
@@ -8,6 +8,14 @@ export class JsExpressionHelper {
     return height && weight ? parseFloat(r) : null;
   }
 
+  calcBSA(height: number, weight: number) {
+    let result;
+    if (height && weight) {
+      result = Math.sqrt((height * weight) / 3600).toFixed(2);
+    }
+    return height && weight ? parseFloat(result) : null;
+  }
+
   calcBMIForAgeZscore(bmiForAgeRef, height, weight) {
     let bmi;
     const maxAgeInDays = 1856;


### PR DESCRIPTION
Adds a helper function that computes `Body Surface Area` (in m²) given `height` in centimetres and `weight` in kilograms:

![BSA-calculation](https://user-images.githubusercontent.com/8509731/106134163-313cc200-6177-11eb-80c9-3417c863c69f.jpg)
