### PR TITLE
Use ngx-pipes for time ago

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9098,6 +9098,21 @@
         "tslib": "^1.9.0"
       }
     },
+    "ngx-pipes": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/ngx-pipes/-/ngx-pipes-2.7.5.tgz",
+      "integrity": "sha512-hlxHzu+snGJ038Z+HdkgEZRlZeE7suDTLWJD1yUP11eAM+xLPJAur1QtvvtZTHRHutOc7Wij1keBtuWIS9D0JQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
     "ngx-webcam": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/ngx-webcam/-/ngx-webcam-0.2.6.tgz",
@@ -12554,14 +12569,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
-    },
-    "time-ago-pipe": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/time-ago-pipe/-/time-ago-pipe-1.3.2.tgz",
-      "integrity": "sha512-ecKcPRPzQ4iDGrcifplKod4/Ael6w65LAw0Ll/IEJBv+CBmKZGMLpgduLWmlgu6Ow8ykwb/Fp2SPqPNDTLpuoQ==",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
     },
     "timed-out": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ngx-bootstrap": "^4.3.0",
     "ngx-cookie": "^4.0.2",
     "ngx-file-uploader": "0.0.18",
+    "ngx-pipes": "^2.7.5",
     "ngx-webcam": "^0.2.2",
     "pdfmake": "0.1.40",
     "reflect-metadata": "^0.1.9",
@@ -42,7 +43,6 @@
     "rxjs-compat": "^6.2.1",
     "shelljs": "^0.7.0",
     "slick-carousel": "^1.6.0",
-    "time-ago-pipe": "^1.3.2",
     "tree-model": "^1.0.5",
     "zone.js": "^0.8.26"
   },

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -37,7 +37,7 @@ import { AppointmentsOverviewComponent } from '../components/appointments-overvi
 import { EncounterViewerModule } from '../encounter-viewer/encounter-viewer.module';
 import { CheckboxModule } from '../components/check-box/checkbox.module';
 import { SharedModule } from '../shared.module';
-import { TimeAgoPipe } from 'time-ago-pipe';
+import { NgPipesModule } from 'ngx-pipes';
 
 @NgModule({
   imports: [
@@ -56,15 +56,15 @@ import { TimeAgoPipe } from 'time-ago-pipe';
     MatTabsModule,
     MatCardModule,
     NgxDateTimePickerModule,
-    SharedModule
+    SharedModule,
+    NgPipesModule
   ],
   declarations: [
     FormRendererComponent,
     AfeNgSelectComponent,
     AppointmentsOverviewComponent,
     HistoricalValueDirective,
-    ErrorRendererComponent,
-    TimeAgoPipe
+    ErrorRendererComponent
   ],
   providers: [
     FormBuilder,


### PR DESCRIPTION
### Description

Moving `openmrs-esm-form-entry-app` to a monorepo requires us to use typescript `version 4^`. Angular compiler doesn't support `time ago pipe as of version 9. I have replaced this with `ngx-pipes` that still has the same functionality