### PR TITLE
Fix ng-select width issue on OpenMRS3.x environment 

### DIFF
--- a/projects/ngx-formentry/styles/ngx-formentry.css
+++ b/projects/ngx-formentry/styles/ngx-formentry.css
@@ -1,13 +1,11 @@
 @import 'picker.min.css';
 .ng-select {
-	padding-bottom: 1.25em
+	padding-bottom: 1.25em;
+	min-width: 16rem;
 }
 
 .ng-select.ng-select-disabled .ng-select-container:after {
 	border-bottom-color: transparent;
-	/* background-image: linear-gradient(to right, rgba(0, 0, 0, 0.42) 0%, rgba(0, 0, 0, 0.42) 33%, transparent 0%);
-	background-size: 4px 1px;
-	background-repeat: repeat-x */
 }
 
 .ng-select.ng-select-disabled .ng-select-container .ng-value-container .ng-value {


### PR DESCRIPTION
### What does this PR do?

- Currently on 3.x environment empty `ng-select` element width is too tiny for good user experience. This PR fixes this issue by setting a `min-width` property for empty select control

### Screenshoot

#### Before

![Screenshot 2021-12-06 at 10 36 32](https://user-images.githubusercontent.com/28008754/144806032-32db36f4-467b-4991-9965-e850bb93a5ed.png)

#### After
![Screenshot 2021-12-06 at 10 36 14](https://user-images.githubusercontent.com/28008754/144806042-b25a5c6b-8fa7-4de2-8539-249c82d3d9f3.png)

