### PR TITLE
03 1127 : (bug) fix expression runner failing while loading form

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
@@ -8,7 +8,7 @@
                 <input [disabled]="isDisabled" (dateTimeChange)="onInput($event)" type="text"
                     class="bx--date-picker__input fill" [id]="id" [value]="value" [owlDateTime]="dt1"
                     [owlDateTimeTrigger]="dt1" placeholder="mm/dd/yyyy" data-date-picker-input />
-                <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;"
+                <svg [owlDateTimeTrigger]="dt1" focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;"
                     xmlns="http://www.w3.org/2000/svg" data-date-picker-icon="true" class="bx--date-picker__icon"
                     width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
                     <path

--- a/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/dialog/dialog-ref.class.ts
+++ b/projects/ngx-formentry/src/components/ngx-pick-datetime/lib/dialog/dialog-ref.class.ts
@@ -56,7 +56,7 @@ export class OwlDialogRef<T> {
                 this.locationChanged.unsubscribe();
                 this._afterClosed$.next(this.result);
                 this._afterClosed$.complete();
-                this.componentInstance = null!;
+                this.componentInstance = null;
             });
 
         this.overlayRef.keydownEvents()

--- a/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
+++ b/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
@@ -56,24 +56,20 @@ export class ExpressionRunner {
 
         // prevent more than one return statements
         if (expression.indexOf('return') === -1) {
-          expression = `"return  ${expression}"`;
+          expression = '"return ' + expression + '"';
         }
-        const afeDynamicFunc = new Function(paramList, expression);
-        scope[Symbol.iterator] = function* () {
-          var k;
-          for (k in this) {
-            yield this[k];
-          }
-        };
+
+        let funcDeclarationCode = `new Function("${paramList}", ${expression}).call(this ${
+          argList === '' ? '' : ',' + argList
+        });`;
 
         try {
           if (Object.keys(scope).indexOf('undefined') >= 0) {
             console.warn('Missing reference found', expression, scope);
             return false;
           }
-          //console.log('Result====>',res)
-          //console.log('results: ', eval(funcDeclarationCode + funcCallCode));
-          return afeDynamicFunc.call(this, ...scope);
+          //console.info('results: ', expression, eval(funcDeclarationCode + funcCallCode));
+          return eval(funcDeclarationCode);
         } catch (e) {
           // if (window['error_count']) {
           //     window['error_count'] = window['error_count'] + 1;

--- a/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
+++ b/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
@@ -8,7 +8,7 @@ import { ArrayNode } from '../form-factory/form-node';
 import { ControlRelationsFactory } from '../form-factory/control-relations.factory';
 import { Form } from '../form-factory/form';
 import * as moment_ from 'moment';
-import { Injectable } from "@angular/core";
+import { Injectable } from '@angular/core';
 
 const moment = moment_;
 @Injectable()
@@ -56,7 +56,7 @@ export class ExpressionRunner {
 
         // prevent more than one return statements
         if (expression.indexOf('return') === -1) {
-          expression = 'return ' + expression;
+          expression = `"return  ${expression}"`;
         }
         const afeDynamicFunc = new Function(paramList, expression);
         scope[Symbol.iterator] = function* () {
@@ -151,16 +151,21 @@ export class ExpressionRunner {
     }
   }
 
-  private setControlQuestion(control: AfeFormArray | AfeFormGroup | AfeFormControl,
-    form: Form, scope: any) {
+  private setControlQuestion(
+    control: AfeFormArray | AfeFormGroup | AfeFormControl,
+    form: Form,
+    scope: any
+  ) {
     if (
       control &&
       control.controlRelations &&
-      control.controlRelations.relations) {
+      control.controlRelations.relations
+    ) {
       control.controlRelations.relations.forEach((relation) => {
         const related = relation.relatedTo as any;
-        const question = form.searchNodeByQuestionId(related.uuid)[0]?.question?.extras;
-        scope["FORM"][related.uuid] = question;
+        const question = form.searchNodeByQuestionId(related.uuid)[0]?.question
+          ?.extras;
+        scope['FORM'][related.uuid] = question;
       });
     }
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- This PR fixes a bug on the expression runner where the `js expression` isn't wrapped correctly resulting in forms not loading correctly. This is seen in 3 forms namely `medication refill`, `infant-followup` and `PRE Initial form`. I have reverted to using `eval` function since the function generator isn't parsing the expression correctly
- Add ability to launch calendar control by clicking the calendar icon

## Screenshots

<img width="348" alt="Screenshot 2022-02-22 at 12 37 08" src="https://user-images.githubusercontent.com/28008754/155106295-fa7ac87f-3431-4b51-b8d7-09ad59ef45aa.png">


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

https://issues.openmrs.org/browse/O3-1127
https://issues.openmrs.org/projects/MF/issues/O3-1113


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
