### PR TITLE
O3 1159:Allow support for read-only fields

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -100,7 +100,8 @@
           'bx--text-area--light': theme === 'light',
           'bx--text-area--invalid': !node.control.valid
       }" [placeholder]="node.question.placeholder" [rows]="node.question.rows" class="bx--text-area"
-            *ngSwitchCase="'textarea'" [formControlName]="node.question.key" [id]="node.question.key + 'id'">
+            *ngSwitchCase="'textarea'" [formControlName]="node.question.key" [id]="node.question.key + 'id'"
+            [readOnly]="node.question.extras.readonly">
         </textarea>
 
           <ngx-remote-select [theme]="theme" *ngSwitchCase="'remote-select'" [placeholder]="node.question.placeholder"

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -101,7 +101,7 @@
           'bx--text-area--invalid': !node.control.valid
       }" [placeholder]="node.question.placeholder" [rows]="node.question.rows" class="bx--text-area"
             *ngSwitchCase="'textarea'" [formControlName]="node.question.key" [id]="node.question.key + 'id'"
-            [readOnly]="node.question.extras.readonly">
+            [readOnly]="node.question.extras.readOnly">
         </textarea>
 
           <ngx-remote-select [theme]="theme" *ngSwitchCase="'remote-select'" [placeholder]="node.question.placeholder"
@@ -129,7 +129,7 @@
 
           <input [theme]="theme" class="bx--text-input" ibmText *ngSwitchDefault [formControlName]="node.question.key"
             [attr.placeholder]="node.question.placeholder" [type]="node.question.renderingType"
-            [id]="node.question.key + 'id'" [readOnly]="node.question.extras.readonly"/>
+            [id]="node.question.key + 'id'" [readOnly]="node.question.extras.readOnly"/>
 
           <div *ngSwitchCase="'radio'">
             <div *ngFor="let o of node.question.options">

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -128,7 +128,7 @@
 
           <input [theme]="theme" class="bx--text-input" ibmText *ngSwitchDefault [formControlName]="node.question.key"
             [attr.placeholder]="node.question.placeholder" [type]="node.question.renderingType"
-            [id]="node.question.key + 'id'" />
+            [id]="node.question.key + 'id'" [readOnly]="node.question.extras.readonly"/>
 
           <div *ngSwitchCase="'radio'">
             <div *ngFor="let o of node.question.options">

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -14,7 +14,7 @@ export interface BaseOptions {
   hide?: string | boolean;
   alert?: any;
   disable?: string | boolean;
-  readonly?: string | boolean;
+  readOnly?: string | boolean;
   enableHistoricalValue?: boolean;
   historicalDataValue?: any;
   calculateExpression?: string;

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -14,6 +14,7 @@ export interface BaseOptions {
   hide?: string | boolean;
   alert?: any;
   disable?: string | boolean;
+  readonly?: string | boolean;
   enableHistoricalValue?: boolean;
   historicalDataValue?: any;
   calculateExpression?: string;

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -34,7 +34,7 @@ export class QuestionBase implements BaseOptions {
   required?: boolean;
   hide?: string | boolean;
   disable?: string | boolean;
-  readonly?: string | boolean;
+  readOnly?: string | boolean;
   calculateExpression?: string;
   componentConfigs: Array<any>;
   options?: any;
@@ -50,7 +50,7 @@ export class QuestionBase implements BaseOptions {
     this.required = options.required;
     this.hide = options.hide;
     this.disable = options.disable;
-    this.readonly = options.readonly;
+    this.readOnly = options.readOnly;
     this.alert = options.alert;
     this.historicalDataValue = options.historicalDataValue;
     this.calculateExpression = options.calculateExpression;

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -34,6 +34,7 @@ export class QuestionBase implements BaseOptions {
   required?: boolean;
   hide?: string | boolean;
   disable?: string | boolean;
+  readonly?: string | boolean;
   calculateExpression?: string;
   componentConfigs: Array<any>;
   options?: any;
@@ -49,6 +50,7 @@ export class QuestionBase implements BaseOptions {
     this.required = options.required;
     this.hide = options.hide;
     this.disable = options.disable;
+    this.readonly = options.readonly;
     this.alert = options.alert;
     this.historicalDataValue = options.historicalDataValue;
     this.calculateExpression = options.calculateExpression;


### PR DESCRIPTION
Added support for declaring a read-only field.
The field will have the same style, however, the user can't change the value.
The readonly attribute is specified in the question, accepting a boolean.  **"readonly": "true"**

Example:
```
{
	"label": "Field label",
	"readonly": "true",
	"questionOptions": {
		"concept": "my-read-only-field-concept",
		"rendering": "text"
	},
	"type": "obs",
	"id": "my_id"
},
```

Thanks,

CC: @enyachoke