### PR TITLE
O3-1186 - Make checkbox component receive id as a prop

### DIFF
--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.html
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.html
@@ -1,7 +1,7 @@
 <fieldset class="bx--fieldset">
   <div class="bx--form-item bx--checkbox-wrapper" *ngFor="let option of options; let i = index">
-    <input type="checkbox" class="bx--checkbox" [id]="i + 'id'" [checked]="option.checked" (change)="selectOpt(option, $event)" [value]="option.value">
-    <label [for]="i + 'id'" class="bx--checkbox-label">
+    <input type="checkbox" class="bx--checkbox" [id]="i + id" [checked]="option.checked" (change)="selectOpt(option, $event)" [value]="option.value">
+    <label [for]="i + id" class="bx--checkbox-label">
       <span class="bx--checkbox-label-text">{{ option.label }}</span>
     </label>
   </div>

--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.ts
@@ -21,6 +21,7 @@ import * as _ from 'lodash';
   ]
 })
 export class CheckboxControlComponent implements OnInit, AfterViewInit {
+  @Input() public id: String;
   @Input() public options: Array<any>;
   @Input() public selected: Array<any>;
   public _value: Array<any> = [];


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/O3-1186

When there are multiple check-boxe groups inside the same page, all of them share the same id.

Solution:
Pass id as a prop into the checkbox component, and assign it 