### PR TITLE
O3-1198 - Make date picker dynamic

### DIFF
--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.component.ts
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.component.ts
@@ -20,6 +20,7 @@ export class NgxDatetimeComponent implements ControlValueAccessor {
   isDisabled = false;
   @Input() id = '';
   @Input() theme = 'dark';
+  @Input() datePickerFormat = '';
   @Input() showWeeks = false;
   @Input() weeks: number[];
   onChange = (_: any) => {};

--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
@@ -36,4 +36,4 @@
     </div>
 
 </div>
-<owl-date-time [pickerType]="'calendar'" [disabled]="isDisabled" #dt1></owl-date-time>
+<owl-date-time [pickerType]="datePickerFormat" [disabled]="isDisabled" #dt1></owl-date-time>

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -183,6 +183,7 @@ export class QuestionFactory {
     };
     question.showTime = true;
     question.componentConfigs = schemaQuestion.componentConfigs || [];
+    question.datePickerFormat = schemaQuestion.datePickerFormat;
 
     this.copyProperties(mappings, schemaQuestion, question);
     this.addDisableOrHideProperty(schemaQuestion, question);

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -109,7 +109,7 @@
 
           <ngx-datetimepicker [weeks]="node.question.extras.questionOptions.weeksList"
             [showWeeks]="node.question.showWeeksAdder" [theme]="theme" [id]="node.question.key + 'id'"
-            [formControlName]="node.question.key" *ngSwitchCase="'date'">
+            [formControlName]="node.question.key" *ngSwitchCase="'date'" [datePickerFormat]="node.question.datePickerFormat">
           </ngx-datetimepicker>
           <ng-select [ngClass]="{'afe-custom': theme === 'light'}" [id]="node.question.key + 'id'"
             *ngSwitchCase="'multi-select'" [items]="node.question.options" bindLabel="label" bindValue="value"

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -25,4 +25,5 @@ export interface BaseOptions {
   historicalDisplay?: any;
   rows?: any;
   showWeeksAdder?: any;
+  datePickerFormat?: any;
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -14,6 +14,7 @@ export class QuestionBase implements BaseOptions {
   historicalDisplay?: any;
   rows?: any;
   showWeeksAdder?: any;
+  datePickerFormat: string;
   key: string;
   alert?: any;
 


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/O3-1198

Deatils:
Date widget is hardcoded to never show time or always show time.

Ideally, this should be a json configuration. 

Solution:
Added to Json the option datePickerFormat.
By changing this option between "calendar" and "both", we can obtain the intended behavior