### PR TITLE
O3-1324 The time displayed for the previous value is miscalculated in form engine

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -124,9 +124,15 @@
         <i class="glyphicon glyphicon-question-sign" aria-hidden="true"></i>
       </a>
 
-      <label *ngIf="node.question.label" [style.color]="hasErrors() ? 'red' : ''" class="bx--label"
-        [attr.for]="node.question.key">
-        {{ node.question.required ? '*' : '' }} {{ node.question.prefix ? node.question.prefix + ' ' : '' }}{{ node.question.label }}
+      <label
+        *ngIf="node.question.label"
+        [style.color]="hasErrors() ? 'red' : ''"
+        class="bx--label"
+        [attr.for]="node.question.key"
+      >
+        {{ node.question.required ? '*' : '' }}
+        {{ node.question.prefix ? node.question.prefix + ' ' : ''
+        }}{{ node.question.label }}
       </label>
 
       <div
@@ -194,9 +200,15 @@
             [id]="node.question.key + 'id'"
           ></ngx-remote-select>
 
-          <ngx-datetimepicker [weeks]="node.question.extras.questionOptions.weeksList"
-            [showWeeks]="node.question.showWeeksAdder" [theme]="theme" [id]="node.question.key + 'id'"
-            [formControlName]="node.question.key" *ngSwitchCase="'date'" [datePickerFormat]="node.question.datePickerFormat">
+          <ngx-datetimepicker
+            [weeks]="node.question.extras.questionOptions.weeksList"
+            [showWeeks]="node.question.showWeeksAdder"
+            [theme]="theme"
+            [id]="node.question.key + 'id'"
+            [formControlName]="node.question.key"
+            *ngSwitchCase="'date'"
+            [datePickerFormat]="node.question.datePickerFormat"
+          >
           </ngx-datetimepicker>
           <ng-select
             [ngClass]="{ 'afe-custom': theme === 'light' }"
@@ -249,7 +261,12 @@
           />
 
           <div *ngSwitchCase="'radio'">
-            <div *ngFor="let o of node.question.options" [ngClass]="{'in-line': node.question.orientation === 'horizontal'}">
+            <div
+              *ngFor="let o of node.question.options"
+              [ngClass]="{
+                'in-line': node.question.orientation === 'horizontal'
+              }"
+            >
               <label class="form-control no-border">
                 <input
                   type="radio"
@@ -286,7 +303,7 @@
                   <span *ngIf="node.question.showHistoricalValueDate">
                     <span> | </span>
                     <strong class="text-primary"
-                      >{{ node.question.historicalDisplay?._date }}
+                      >{{ node.question.historicalDisplay?._date | date }}
                     </strong>
                     <span
                       class="text-primary"

--- a/projects/ngx-formentry/src/form-entry/services/historical-encounter-data.service.ts
+++ b/projects/ngx-formentry/src/form-entry/services/historical-encounter-data.service.ts
@@ -59,7 +59,9 @@ export class HistoricalEncounterDataService {
     if (answers.length > 0) {
       return {
         value: answers[0],
-        valueDate: moment(object.encounterDatetime).format('ll')
+        valueDate: moment(object.encounterDatetime).format(
+          'YYYY-MM-DDTHH:mm:ss'
+        )
       };
     }
   }

--- a/src/app/mock/mock-obs.ts
+++ b/src/app/mock/mock-obs.ts
@@ -2,7 +2,7 @@ export class MockObs {
   getObs(): any {
     return {
       uuid: 'encounter-uuid',
-      encounterDatetime: '2016-01-21T16:17:46.000+0300',
+      encounterDatetime: '2022-06-01T10:10:46.000+0300',
       patient: {
         uuid: 'patient-uuid'
       },
@@ -23,6 +23,15 @@ export class MockObs {
         display: '5566790 - H Dengue Provider'
       },
       obs: [
+        {
+          uuid: '0bc6ef97-7727-4787-8c16-fc21460ccafd',
+          obsDatetime: '2016-01-21T01:17:46.000+0300',
+          concept: {
+            uuid: 'a899a9f2-1350-11df-a1f1-0026b9348838'
+          },
+          value: 'a899af10-1350-11df-a1f1-0026b9348838',
+          groupMembers: null
+        },
         {
           uuid: 'ac55c445-9661-4d42-86b5-4d6ec33a6274',
           obsDatetime: '2016-01-21T16:17:46.000+0300',


### PR DESCRIPTION
In the AMPATH form while using the historical expression (previous value) the hours were miscalculated.
The date format was changed so this calculation could work, and on the front-end, we format it again so it can display the date correctly.

Desired result:
![image](https://user-images.githubusercontent.com/106243905/174758721-23cef408-4834-43f7-acd8-8615a4fef32a.png)


OpenMRS Issue:
https://issues.openmrs.org/browse/O3-1324