### PR TITLE
Added autopopulate function to handle autopopulated inputs

### DIFF
--- a/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.ts
+++ b/projects/ngx-formentry/src/abstract-controls-extension/afe-form-control.ts
@@ -23,6 +23,7 @@ import { HiderHelper } from '../form-entry/control-hiders-disablers/hider-helper
 import { AlertHelper } from '../form-entry/control-alerts/alert-helpers';
 import { DisablerHelper } from '../form-entry/control-hiders-disablers/disabler-helper';
 import { CanCalculate } from '../form-entry/control-calculators/can-calculate';
+import { CanAutopopulate } from '../form-entry/can-autopopulate/can-autopopulate';
 import { ExpressionRunner } from '../form-entry/expression-runner/expression-runner';
 
 class AfeFormControl
@@ -31,6 +32,7 @@ class AfeFormControl
     CanHide,
     CanDisable,
     CanCalculate,
+    CanAutopopulate,
     CanGenerateAlert,
     ValueChangeListener {
   private _controlRelations: ControlRelations;
@@ -44,6 +46,7 @@ class AfeFormControl
   alert: string;
   alerts: Alert[];
   calculator: Function;
+  autopopulate: Function;
   disablers: Disabler[];
 
   private hiderHelper: HiderHelper = new HiderHelper();
@@ -96,6 +99,17 @@ class AfeFormControl
   updateCalculatedValue() {
     if (this.calculator) {
       const _val = this.calculator.call(ExpressionRunner, {});
+      this.setValue(_val);
+    }
+  }
+
+  setAutopopulateFn(newAutopopulate: Function) {
+    this.autopopulate = newAutopopulate;
+  }
+
+  updateAutopopulatedValue() {
+    if (this.autopopulate) {
+      const _val = this.autopopulate.call(ExpressionRunner, {});
       this.setValue(_val);
     }
   }

--- a/projects/ngx-formentry/src/change-tracking/control-relation.ts
+++ b/projects/ngx-formentry/src/change-tracking/control-relation.ts
@@ -34,6 +34,10 @@ export class ControlRelation {
         (this._control as any).updateCalculatedValue();
       }
 
+      if ((this._control as any).updateAutopopulatedValue) {
+        (this._control as any).updateAutopopulatedValue();
+      }
+
       this._control.updateValueAndValidity();
       if ((this._control as any).updateHiddenState) {
         (this._control as any).updateHiddenState();

--- a/projects/ngx-formentry/src/form-entry/can-autopopulate/can-autopopulate.ts
+++ b/projects/ngx-formentry/src/form-entry/can-autopopulate/can-autopopulate.ts
@@ -1,0 +1,5 @@
+export interface CanAutopopulate {
+  autopopulate: Function;
+  setAutopopulateFn(newAutopopulate: Function);
+  updateAutopopulatedValue();
+}

--- a/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
+++ b/projects/ngx-formentry/src/form-entry/expression-runner/expression-runner.ts
@@ -17,6 +17,7 @@ export class ExpressionRunner {
     expression: string,
     control: AfeFormArray | AfeFormGroup | AfeFormControl,
     helper: any,
+    autopopulate: any,
     dataDependencies: any,
     form?: Form
   ): Runnable {
@@ -35,6 +36,7 @@ export class ExpressionRunner {
         runner.setControlQuestion(control, form, scope);
         runner.getControlRelationValueString(control, scope);
         runner.getHelperMethods(helper, scope);
+        runner.getAutopopulateMethods(autopopulate, scope);
         runner.getDataDependencies(dataDependencies, scope);
         if (form) {
           // console.error('Form defined', form);
@@ -161,7 +163,7 @@ export class ExpressionRunner {
     ) {
       control.controlRelations.relations.forEach((relation) => {
         const related = relation.relatedTo as any;
-        const question = form.searchNodeByQuestionId(related.uuid)[0]?.question
+        const question = form?.searchNodeByQuestionId(related.uuid)[0]?.question
           ?.extras;
         scope['FORM'][related.uuid] = question;
       });
@@ -210,6 +212,14 @@ export class ExpressionRunner {
   }
 
   private getHelperMethods(obj: any, scope?: any) {
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        scope[key] = obj[key];
+      }
+    }
+  }
+
+  private getAutopopulateMethods(obj: any, scope?: any) {
     for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
         scope[key] = obj[key];

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -24,6 +24,7 @@ import { HidersDisablersFactory } from './form-factory/hiders-disablers.factory'
 import { AlertsFactory } from './form-factory/show-messages.factory';
 import { ExpressionRunner } from './expression-runner/expression-runner';
 import { JsExpressionHelper } from './helpers/js-expression-helper';
+import { JsExpressionAutopopulate } from './helpers/autopopulate-expression-helper';
 import { FormSchemaCompiler } from './services/form-schema-compiler.service';
 import { FormFactory } from './form-factory/form.factory';
 import { QuestionFactory } from './form-factory/question.factory';
@@ -83,6 +84,7 @@ import { CustomComponentWrapperModule } from '../components/custom-component-wra
     AlertsFactory,
     ExpressionRunner,
     JsExpressionHelper,
+    JsExpressionAutopopulate,
     HistoricalFieldHelperService,
     FormSchemaCompiler,
     FormFactory,

--- a/projects/ngx-formentry/src/form-entry/form-factory/control-relations.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/control-relations.factory.ts
@@ -119,6 +119,8 @@ export class ControlRelationsFactory {
                     | AfeFormArray).addValueChangeListener((value) => {
                     if ((rootControl as any).updateCalculatedValue) {
                       (rootControl as any).updateCalculatedValue();
+                    } else if ((rootControl as any).updateAutopopulatedValue) {
+                      (rootControl as any).updateAutopopulatedValue();
                     }
 
                     rootControl.updateValueAndValidity();
@@ -290,6 +292,13 @@ export class ControlRelationsFactory {
       questionBase.calculateExpression &&
       questionBase.calculateExpression.length > 0 &&
       questionBase.calculateExpression.indexOf(id) !== -1
+    ) {
+      hasRelation = true;
+    } else if (
+      !hasRelation &&
+      questionBase.autopopulateExpression &&
+      questionBase.autopopulateExpression.length > 0 &&
+      questionBase.autopopulateExpression.indexOf(id) !== -1
     ) {
       hasRelation = true;
     }

--- a/projects/ngx-formentry/src/form-entry/form-factory/form-control.service.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form-control.service.ts
@@ -21,7 +21,7 @@ import {
   Runnable
 } from '../expression-runner/expression-runner';
 import { JsExpressionHelper } from '../helpers/js-expression-helper';
-
+import { JsExpressionAutopopulate } from '../helpers/autopopulate-expression-helper';
 @Injectable()
 export class FormControlService {
   controls = [];
@@ -145,6 +145,12 @@ export class FormControlService {
       form,
       form.dataSourcesContainer.dataSources
     );
+    this.wireAutopopulator(
+      question,
+      control,
+      form,
+      form.dataSourcesContainer.dataSources
+    );
 
     if (parentControl instanceof AfeFormGroup) {
       parentControl.setControl(question.key, control);
@@ -209,6 +215,29 @@ export class FormControlService {
       );
       // this functionality strictly assumes the calculateExpression function has been defined in the JsExpressionHelper class
       control.setCalculatorFn(runnable.run);
+    }
+  }
+  // autopopulate values based on previous inputs
+  private wireAutopopulator(
+    question: QuestionBase,
+    control: AfeFormControl,
+    form: Form,
+    dataSource?: any
+  ) {
+    if (
+      question.autopopulateExpression &&
+      question.autopopulateExpression !== ''
+    ) {
+      const autopopulate: JsExpressionAutopopulate = new JsExpressionAutopopulate();
+      const runner: ExpressionRunner = new ExpressionRunner();
+      const runnable: Runnable = runner.getRunnable(
+        question.autopopulateExpression,
+        control,
+        autopopulate.autopopulateFunctions,
+        dataSource,
+        form
+      );
+      control.setAutopopulateFn(runnable.run);
     }
   }
 }

--- a/projects/ngx-formentry/src/form-entry/form-factory/hiders-disablers.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/hiders-disablers.factory.ts
@@ -14,6 +14,7 @@ import {
 } from '../../abstract-controls-extension';
 import { QuestionBase } from '../question-models/question-base';
 import { JsExpressionHelper } from '../helpers/js-expression-helper';
+import { JsExpressionAutopopulate } from '../helpers/autopopulate-expression-helper';
 import { Form } from './form';
 // Add ability to display all fields for debugging
 import { DebugModeService } from './../services/debug-mode.service';
@@ -23,6 +24,7 @@ export class HidersDisablersFactory {
   constructor(
     private expressionRunner: ExpressionRunner,
     private expressionHelper: JsExpressionHelper,
+    private expressionAutopopulate: JsExpressionAutopopulate,
     private _debugModeService: DebugModeService
   ) {}
 
@@ -35,6 +37,7 @@ export class HidersDisablersFactory {
       question.disable as string,
       control,
       this.expressionHelper.helperFunctions,
+      this.expressionAutopopulate.autopopulateFunctions,
       {},
       form
     );

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -79,6 +79,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -108,6 +109,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -137,6 +139,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -165,6 +168,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -194,6 +198,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -224,6 +229,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -260,6 +266,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -292,6 +299,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -320,6 +328,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -344,6 +353,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -367,6 +377,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -390,6 +401,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -417,6 +429,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -453,6 +466,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -478,6 +492,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -553,6 +568,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -583,6 +599,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -621,6 +638,7 @@ export class QuestionFactory {
     this.addAlertProperty(schemaQuestion, question);
     this.addHistoricalExpressions(schemaQuestion, question);
     this.addCalculatorProperty(schemaQuestion, question);
+    this.addAutopoulateProperty(schemaQuestion, question);
     return question;
   }
 
@@ -961,6 +979,16 @@ export class QuestionFactory {
     ) {
       question.calculateExpression =
         schemaQuestion.questionOptions.calculate.calculateExpression;
+    }
+  }
+
+  addAutopoulateProperty(schemaQuestion: any, question: QuestionBase): any {
+    if (
+      schemaQuestion.questionOptions &&
+      typeof schemaQuestion.questionOptions.autopopulate === 'object'
+    ) {
+      question.autopopulateExpression =
+        schemaQuestion.questionOptions.autopopulate.autopopulateExpression;
     }
   }
 

--- a/projects/ngx-formentry/src/form-entry/form-factory/show-messages.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/show-messages.factory.ts
@@ -14,12 +14,14 @@ import {
 import { QuestionBase } from '../question-models/question-base';
 import { JsExpressionHelper } from '../helpers/js-expression-helper';
 import { Form } from './form';
+import { JsExpressionAutopopulate } from '../helpers/autopopulate-expression-helper';
 
 @Injectable()
 export class AlertsFactory {
   constructor(
     private expressionRunner: ExpressionRunner,
-    private expressionHelper: JsExpressionHelper
+    private expressionHelper: JsExpressionHelper,
+    private expressionAutopopulate: JsExpressionAutopopulate,
   ) {}
   getJsExpressionshowAlert(
     question: QuestionBase,
@@ -30,6 +32,7 @@ export class AlertsFactory {
       question.alert.alertWhenExpression,
       control,
       this.expressionHelper.helperFunctions,
+      this.expressionAutopopulate.autopopulateFunctions,
       {},
       form
     );

--- a/projects/ngx-formentry/src/form-entry/helpers/autopopulate-expression-helper.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/autopopulate-expression-helper.ts
@@ -1,0 +1,59 @@
+import * as _ from 'lodash';
+import { Injectable } from '@angular/core';
+
+Injectable();
+
+export class JsExpressionAutopopulate {
+  autopopHtsTest(initialTest, confirmatoryTest) {
+    let finalTest;
+    if (
+      initialTest === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+      confirmatoryTest === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    ) {
+      finalTest = '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    } else if (
+      (initialTest === '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+        confirmatoryTest === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA') ||
+      (initialTest === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+        confirmatoryTest === '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+    ) {
+      finalTest = '1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    } else if (
+      initialTest === '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+      confirmatoryTest === '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    ) {
+      finalTest = '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    } else if (
+      (initialTest === '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+        confirmatoryTest === '1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA') ||
+      (initialTest === '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' &&
+        confirmatoryTest === '1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+    ) {
+      finalTest = '1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    }
+    return initialTest && confirmatoryTest ? finalTest : null;
+  }
+
+  autopopNutritionStatus(bmi) {
+    let nutritionStatus;
+    if (bmi < 16 && bmi > 1) {
+      nutritionStatus = '163302AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    } else if (bmi > 16 && bmi < 18.5) {
+      nutritionStatus = '163303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    } else if (bmi > 18.5 && bmi < 25) {
+      nutritionStatus = '1115AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    } else if (bmi >= 25) {
+      nutritionStatus = '114413AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    }
+
+    return bmi ? nutritionStatus : null;
+  }
+
+  get autopopulateFunctions() {
+    const autopopulate = this;
+    return {
+      autopopHtsTest: autopopulate.autopopHtsTest,
+      autopopNutritionStatus: autopopulate.autopopNutritionStatus
+    };
+  }
+}

--- a/projects/ngx-formentry/src/form-entry/helpers/historical-expression-helper-service.ts
+++ b/projects/ngx-formentry/src/form-entry/helpers/historical-expression-helper-service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { HistoricalEncounterDataService } from '../services/historical-encounter-data.service';
 import { JsExpressionHelper } from './js-expression-helper';
+import { JsExpressionAutopopulate } from './autopopulate-expression-helper';
 import {
   Runnable,
   ExpressionRunner
@@ -32,12 +33,14 @@ export class HistoricalHelperService {
     }
 
     const helper = new JsExpressionHelper();
+    const autopopulate = new JsExpressionAutopopulate();
     const control: AfeFormControl = new AfeFormControl();
     const runner: ExpressionRunner = new ExpressionRunner();
     const runnable: Runnable = runner.getRunnable(
       expr,
       control,
       helper.helperFunctions,
+      autopopulate.autopopulateFunctions,
       deps
     );
 

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -18,6 +18,7 @@ export interface BaseOptions {
   enableHistoricalValue?: boolean;
   historicalDataValue?: any;
   calculateExpression?: string;
+  autopopulateExpression?: string;
   questions?: any;
   placeholder?: any;
   hidden?: any;

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -39,6 +39,7 @@ export class QuestionBase implements BaseOptions {
   disable?: string | boolean;
   readOnly?: string | boolean;
   calculateExpression?: string;
+  autopopulateExpression?: string;
   componentConfigs: Array<any>;
   options?: any;
 
@@ -57,6 +58,7 @@ export class QuestionBase implements BaseOptions {
     this.alert = options.alert;
     this.historicalDataValue = options.historicalDataValue;
     this.calculateExpression = options.calculateExpression;
+    this.autopopulateExpression = options.autopopulateExpression;
   }
 
   setHistoricalValue(v: boolean) {

--- a/projects/ngx-formentry/src/form-entry/validators/js-expression.validator.ts
+++ b/projects/ngx-formentry/src/form-entry/validators/js-expression.validator.ts
@@ -1,6 +1,7 @@
 import { AfeFormControl } from '../../abstract-controls-extension/afe-form-control';
 import { ExpressionRunner } from '../expression-runner/expression-runner';
 import { JsExpressionHelper } from '../helpers/js-expression-helper';
+import { JsExpressionAutopopulate } from '../helpers/autopopulate-expression-helper';
 import { JsExpressionValidationModel } from '../question-models/js-expression-validation.model';
 import { Validations } from './validations';
 
@@ -16,13 +17,16 @@ export class JsExpressionValidator {
 
       const expression = model.failsWhenExpression;
       const helper = new JsExpressionHelper();
+      const autopopulate = new JsExpressionAutopopulate();
       const dataDependencies = {};
 
       const helperFunctions = helper.helperFunctions;
+      const autopopulateFunctions = autopopulate.autopopulateFunctions;
       const runnable = new ExpressionRunner().getRunnable(
         expression,
         control,
         helperFunctions,
+        autopopulateFunctions,
         dataDependencies,
         form
       );

--- a/projects/ngx-formentry/src/lib/index.ts
+++ b/projects/ngx-formentry/src/lib/index.ts
@@ -50,3 +50,4 @@ export { NestedQuestion } from '../form-entry/question-models/interfaces/nested-
 export { DateTimePickerModule } from '../components/date-time-picker/date-time-picker.module';
 export { NgxDateTimePickerModule } from '../components/ngx-datetime-picker/ngx-datetime-picker.module';
 export { JsExpressionHelper } from '../form-entry/helpers/js-expression-helper';
+export { JsExpressionAutopopulate } from '../form-entry/helpers/autopopulate-expression-helper';

--- a/src/app/adult-1.6.json
+++ b/src/app/adult-1.6.json
@@ -7986,6 +7986,176 @@
 					]
 				}
 			]
-		}
+		},
+		{
+			"label": "Test Autopopulate Section",
+			"isExpanded": "true",
+			"sections": [
+				{
+					"label": "HTS Test Section",
+					"isExpanded": "true",
+					"questions": [
+						{
+							"label": "Initial Test Results:",
+							"type": "obs",
+							"questionOptions": {
+								"rendering": "select",
+								"concept": "159427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+								"answers": [
+									{
+										"concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Positive"
+									},
+									{
+										"concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Negative"
+									},
+									{
+										"concept": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Inconclusive"
+									}
+								]
+							},
+							"id": "initialTestResult",
+							"validators": []
+						},
+						{
+							"label": "Confirmatory Test Results:",
+							"type": "obs",
+							"questionOptions": {
+								"rendering": "select",
+								"concept": "159427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+								"answers": [
+									{
+										"concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Positive"
+									},
+									{
+										"concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Negative"
+									},
+									{
+										"concept": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Inconclusive"
+									}
+								]
+							},
+							"id": "confirmatoryTestResult",
+							"validators": []
+						},
+						{
+							"label": "Final Test Results:",
+							"type": "obs",
+							"questionOptions": {
+								"rendering": "select",
+								"concept": "159427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+								"answers": [
+									{
+										"concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Positive"
+									},
+									{
+										"concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Negative"
+									},
+									{
+										"concept": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Inconclusive"
+									}
+								],
+								"autopopulate": {
+									"autopopulateExpression": "autopopHtsTest(initialTestResult,confirmatoryTestResult)"
+								}
+							},
+							"id": "finalTestResult",
+							"validators": []
+						}
+					]
+				}
+			]		
+		},
+		{
+			"label": "Nutrition Autopopulate Section",
+			"isExpanded": "true",
+			"sections": [
+				{
+					"label": "Nutrition Test Section",
+					"isExpanded": "true",
+					"questions": [
+						{
+							"label": "Weight (Kg):",
+							"id": "weight",
+							"questionOptions": {
+								"rendering": "number",
+								"concept": "a8a660ca-1350-11df-a1f1-0026b9348838",
+								"max": "250",
+								"min": "0"
+							},
+							"type": "obs",
+							"validators": []
+						},
+						{
+							"label": "Height (Cm):",
+							"historicalExpression": "_.isEmpty(HD.getObject('prevEnc').getValue('a8a6619c-1350-11df-a1f1-0026b9348838')) ? undefined : HD.getObject('prevEnc').getValue('a8a6619c-1350-11df-a1f1-0026b9348838')",
+							"id": "height",
+							"questionOptions": {
+								"rendering": "number",
+								"concept": "a8a6619c-1350-11df-a1f1-0026b9348838",
+								"max": "228",
+								"min": "0"
+							},
+							"type": "obs",
+							"validators": []
+						},
+						{
+							"label": "BMI (Kg/m2):",
+							"id": "bmi",
+							"questionOptions": {
+								"rendering": "number",
+								"concept": "a89c60c0-1350-11df-a1f1-0026b9348838",
+								"max": "100",
+								"min": "0",
+								"calculate": {
+									"calculateExpression": "calcBMI(height,weight)"
+								}
+							},
+							"type": "obs",
+							"validators": []
+						},
+						{
+							"label": "Nutritional status",
+							"type": "obs",
+							"id": "nutritionalStatus",
+							"questionOptions": {
+								"concept": "163300AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+								"rendering": "radio",
+								"answers": [
+									{
+										"concept": "163303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Moderate acute malnutrition"
+									},
+									{
+										"concept": "114413AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Overweight/Obese"
+									},
+									{
+										"concept": "163302AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Severe acute malnutrition"
+									},
+									{
+										"concept": "1115AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+										"label": "Normal"
+									}
+								],
+								"autopopulate": {
+									"autopopulateExpression": "autopopNutritionStatus(bmi)"
+								}
+							}
+						}
+					]
+				}
+			]		
+		}	
+
 	]
 }


### PR DESCRIPTION
Summary :
In forms, there certain input fields that are automatically pre-populated based on previous answers and a specified logic. eg if a patient has a bmi of  less than 16, then their nutrition status is malnutrition and a user does not have to input that manually as it can be added logically.

This pr has the addition of ```autopopulate``` tag in question options which returns a value/concept based on logic specified(helper function) in an ```autopopulateExpression```.

eg: 
```
"autopopulate": {
    "autopopulateExpression": "autopopNutritionStatus(bmi)"
}
```

Video : 

https://user-images.githubusercontent.com/19533785/179769594-381c0e3c-04e4-4c01-86f4-7fad4cb4378d.mp4
