### PR TITLE
Repeating type must support the min and max attributes

### DIFF
--- a/projects/ngx-formentry/src/form-entry/form-factory/form-node.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form-node.ts
@@ -161,7 +161,7 @@ export class ArrayNode extends NodeBase implements ChildNodeCreatedListener {
         return g;
       }
     } else {
-      const removePrompt = confirm('Are you sure you want to remove?');
+      const removePrompt = confirm('Are you sure you want to delete this item?');
       if (removePrompt) {
         if (this.removeChildFunc) {
           this.removeChildFunc(index, this);

--- a/projects/ngx-formentry/src/form-entry/form-factory/form.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form.factory.ts
@@ -200,7 +200,7 @@ export class FormFactory {
     const group = factory.createGroupNode(groupQuestion, null, null, node.form);
 
     if (position >= 0) {
-      node.children.splice(position, 0, group)
+      node.children.splice(position, 0, group);
     } else {
       node.children.push(group);
     }

--- a/projects/ngx-formentry/src/form-entry/form-factory/form.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form.factory.ts
@@ -32,7 +32,7 @@ export class FormFactory {
     public controlService: FormControlService,
     public questionFactroy: QuestionFactory,
     public controlRelationsFactory: ControlRelationsFactory
-  ) { }
+  ) {}
 
   createForm(schema: any, dataSource?: any): Form {
     const form: Form = new Form(schema, this, this.questionFactroy);

--- a/projects/ngx-formentry/src/form-entry/form-factory/form.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/form.factory.ts
@@ -32,7 +32,7 @@ export class FormFactory {
     public controlService: FormControlService,
     public questionFactroy: QuestionFactory,
     public controlRelationsFactory: ControlRelationsFactory
-  ) {}
+  ) { }
 
   createForm(schema: any, dataSource?: any): Form {
     const form: Form = new Form(schema, this, this.questionFactroy);
@@ -179,7 +179,8 @@ export class FormFactory {
   createArrayNodeChild(
     question: RepeatingQuestion,
     node: ArrayNode,
-    factory?: FormFactory
+    factory?: FormFactory,
+    position?: number
   ): GroupNode {
     if (factory === null || factory === undefined) {
       factory = this;
@@ -197,7 +198,12 @@ export class FormFactory {
     }
 
     const group = factory.createGroupNode(groupQuestion, null, null, node.form);
-    node.children.push(group);
+
+    if (position >= 0) {
+      node.children.splice(position, 0, group)
+    } else {
+      node.children.push(group);
+    }
 
     if (node.control instanceof AfeFormArray) {
       const nodeControl = node.control as AfeFormArray;

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -362,6 +362,10 @@
   <div [ngSwitch]="node.question.renderingType">
     <div class="well" style="padding: 2px" *ngSwitchCase="'repeating'">
       <h4 style="margin: 2px; font-weight: bold">{{ node.question.label }}</h4>
+      <div>
+        <label class="bx--label" *ngIf="node.question.extras.questionOptions.min" style="margin-right: 2px">min: {{ node.question.extras.questionOptions.min }}</label>
+        <label class="bx--label" *ngIf="node.question.extras.questionOptions.max">max: {{ node.question.extras.questionOptions.max }}</label>
+      </div>
       <hr
         style="
           margin-left: -2px;
@@ -412,7 +416,8 @@
               [labelMap]="labelMap"
             ></form-renderer>
             <button
-              type="button "
+              type="button"
+              style="width: 100px"
               class="bx--btn bx--btn--danger bx--btn--sm"
               (click)="node.removeAt(i)"
             >
@@ -433,8 +438,10 @@
       </div>
       <button
         type="button"
-        class="bx--btn bx--btn--primary"
+        class="bx--btn bx--btn--primary bx--btn--sm"
+        style="width: 100px"
         (click)="node.createChildNode()"
+        [ngClass]="{ disabled: node.children.length >= node.question.extras.questionOptions.max }"
       >
         Add
       </button>

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -73,6 +73,12 @@ export class FormRendererComponent implements OnInit, OnChanges {
     if (this.parentComponent) {
       this.parentComponent.addChildComponent(this);
     }
+
+    if (this.node && this.node.question.renderingType === 'repeating' && this?.node?.question?.extras?.questionOptions?.min) {
+      for (let index = this.node.children.length; index < this?.node?.question?.extras?.questionOptions?.min; index++) {
+        this.node.createChildNode();
+      }
+    }
   }
 
   public ngOnChanges(changes: SimpleChanges) {

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.ts
@@ -74,8 +74,8 @@ export class FormRendererComponent implements OnInit, OnChanges {
       this.parentComponent.addChildComponent(this);
     }
 
-    if (this.node && this.node.question.renderingType === 'repeating' && this?.node?.question?.extras?.questionOptions?.min) {
-      for (let index = this.node.children.length; index < this?.node?.question?.extras?.questionOptions?.min; index++) {
+    if (this.node && this.node.question.renderingType === 'repeating' && this?.node?.question?.extras?.questionOptions?.min >= 0) {
+      for (let index = this.node.children.length; index < this.node.question.extras.questionOptions.min; index++) {
         this.node.createChildNode();
       }
     }

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/repeating-question-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/repeating-question-options.ts
@@ -3,4 +3,6 @@ import { BaseOptions } from '../interfaces/base-options';
 
 export interface RepeatingQuestionOptions extends BaseOptions {
   questions: QuestionBase[];
+  min?: number;
+  max?: number;
 }


### PR DESCRIPTION
In AMPATH module, the "repeating" type must support both minimum and maximum attributes.

- The minimum attribute represents the minimum number of input sections supported for that group. The entries of the group must open automatically with the minimum number.

- Eg: "min": 3 , will show 3 input sections when the form is opened.

- When the user tries to remove an element and the minimum limit is reached, the section of the "removed" button should be cleared and not removed.

- The max attribute should limit the number of input sections. When the maximum is reached, the "Add" button should be marked as "disabled".

- It should be added below the group title, the minimum and maximum possible values for this group (if available).

![min_max_repeating](https://user-images.githubusercontent.com/94977371/182851160-92357b7a-314a-451e-b2e1-152e66f3489f.gif)


