### PR TITLE
(upgrade) Updgrade form-entry to use Carbon 11 styling

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,7 +23,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.css","projects/ngx-formentry/styles/ngx-formentry.css"],
+            "styles": ["src/styles.scss","projects/ngx-formentry/styles/ngx-formentry.css"],
             "stylePreprocessorOptions": {
               "includePaths": ["projects/ngx-formentry/styles","dist"]
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2973,308 +2973,86 @@
         }
       }
     },
-    "@carbon/telemetry": {
-      "version": "0.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.0.0-alpha.6.tgz",
-      "integrity": "sha512-DCE8ui/tFi+qvCH+mewbUbWzsiq5Ko3HU1lgrVbpjWv1LfswLKFmMg4Os+PmX6edYoBj39qVChJPeaN/UyfJDw==",
-      "dev": true,
+    "@carbon/colors": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.4.0.tgz",
+      "integrity": "sha512-RgZthBiL0QzHzvz4RmGjXBBDsOzMTd94ShbJsobp9Xkf3oosInPnOAXiqY6FvwbX+ByyeB/dxihNApY9Lq6Efg=="
+    },
+    "@carbon/feature-flags": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-0.8.0.tgz",
+      "integrity": "sha512-R0RdoGA9MVv2VwvXaSnJeAW8QoO4P7RLIOi98FfOI3OmjtKPwj66UJVaxZ/63SFjDPV1deTw3k90wXHfEUCmUw=="
+    },
+    "@carbon/grid": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.5.0.tgz",
+      "integrity": "sha512-Sqvg+cAeVzoqI0Yfz6oMvte41HXroH/MVrcBx2bR5F7D9DO+9c8B/AcD7NdIdYtYnOQalwE3BnGdbaYJP73rDA==",
       "requires": {
-        "@babel/parser": "^7.12.5",
-        "@babel/traverse": "^7.12.5",
-        "ci-info": "^2.0.0",
-        "configstore": "^5.0.1",
-        "fast-glob": "^3.2.4",
-        "fs-extra": "^9.0.1",
-        "got": "^11.8.0",
-        "semver": "^7.3.2",
-        "winston": "^3.3.3",
-        "yargs": "^16.1.1"
+        "@carbon/layout": "^11.5.0"
+      }
+    },
+    "@carbon/layout": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.5.0.tgz",
+      "integrity": "sha512-5uZN5gll/JoMMaTW1ZCauL62RqWwYvvOTT/tfCOADSAeUz2Gvnnu8FV4wPwm06wt5u4SFQdSXb45DBVcHFtzPw=="
+    },
+    "@carbon/motion": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.3.0.tgz",
+      "integrity": "sha512-uhseTXlSXBH7FA2euriLYrFcKZqx65raXyVN0F1XIiw3dDfTOwdXGLdg8nPQB3sGVefTinEvGxqwc6dwinbsNA=="
+    },
+    "@carbon/styles": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.9.0.tgz",
+      "integrity": "sha512-PI0uuegz4cnexmtiorlwRaYeosF9cF9kyM08267gS5KnG87BojiG/U78oqQKD0zcuN9yatdTkYgGwfbmgTOihg==",
+      "requires": {
+        "@carbon/colors": "^11.4.0",
+        "@carbon/feature-flags": "^0.8.0",
+        "@carbon/grid": "^11.5.0",
+        "@carbon/layout": "^11.5.0",
+        "@carbon/motion": "^11.3.0",
+        "@carbon/themes": "^11.6.0",
+        "@carbon/type": "^11.6.0",
+        "@ibm/plex": "6.0.0-next.6"
+      }
+    },
+    "@carbon/themes": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.6.0.tgz",
+      "integrity": "sha512-NpO/GXvuIWycMCHy36HF0Mdegq8zgj9mLTkFyoIMGWRCGZuKbWiNy0xT18XQsTTCOedc41V+EMWOrIxCv60n1w==",
+      "requires": {
+        "@carbon/colors": "^11.4.0",
+        "@carbon/layout": "^11.5.0",
+        "@carbon/type": "^11.6.0",
+        "color": "^3.1.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
+        "color": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+          "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
           "requires": {
-            "color-convert": "^2.0.1"
+            "color-convert": "^1.9.3",
+            "color-string": "^1.6.0"
           }
         },
-        "ci-info": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
+        "color-string": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+          "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
           "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
           }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "configstore": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-          "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^5.2.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^3.0.0",
-            "unique-string": "^2.0.0",
-            "write-file-atomic": "^3.0.0",
-            "xdg-basedir": "^4.0.0"
-          }
-        },
-        "crypto-random-string": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-          "dev": true
-        },
-        "dot-prop": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^2.0.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "got": {
-          "version": "11.8.2",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-          "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "@szmarczak/http-timer": "^4.0.5",
-            "@types/cacheable-request": "^6.0.1",
-            "@types/responselike": "^1.0.0",
-            "cacheable-lookup": "^5.0.3",
-            "cacheable-request": "^7.0.1",
-            "decompress-response": "^6.0.0",
-            "http2-wrapper": "^1.0.0-beta.5.2",
-            "lowercase-keys": "^2.0.0",
-            "p-cancelable": "^2.0.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "is-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "unique-string": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "write-file-atomic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-          "dev": true,
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
-        },
-        "xdg-basedir": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-          "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-          "dev": true
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.7",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
-          "dev": true
         }
       }
     },
-    "@dabh/diagnostics": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-      "dev": true,
+    "@carbon/type": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.6.0.tgz",
+      "integrity": "sha512-2W7llkafQ3BzJHhmTfRPXmFD6FgEAeO1PJklSYFNnxLgV6/AhtU4nNUZ7oLQ6Y6uM4DPaT6peeWxTOgHm1DWRQ==",
       "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
+        "@carbon/grid": "^11.5.0"
       }
     },
     "@discoveryjs/json-ext": {
@@ -3282,6 +3060,11 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
       "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
       "dev": true
+    },
+    "@ibm/plex": {
+      "version": "6.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-6.0.0-next.6.tgz",
+      "integrity": "sha512-B3uGruTn2rS5gweynLmfSe7yCawSRsJguJJQHVQiqf4rh2RNgJFu8YLE2Zd/JHV0ZXoVMOslcXP2k3hMkxKEyA=="
     },
     "@istanbuljs/schema": {
       "version": "0.1.3",
@@ -3864,21 +3647,6 @@
         }
       }
     },
-    "@sindresorhus/is": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
-      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
-      "dev": true
-    },
-    "@szmarczak/http-timer": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-      "dev": true,
-      "requires": {
-        "defer-to-connect": "^2.0.0"
-      }
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3890,18 +3658,6 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
       "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
       "dev": true
-    },
-    "@types/cacheable-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-      "dev": true,
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
-        "@types/node": "*",
-        "@types/responselike": "*"
-      }
     },
     "@types/component-emitter": {
       "version": "1.2.10",
@@ -3937,12 +3693,6 @@
         "@types/node": "*"
       }
     },
-    "@types/http-cache-semantics": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
-      "dev": true
-    },
     "@types/jasmine": {
       "version": "3.6.11",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.11.tgz",
@@ -3963,15 +3713,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
-    },
-    "@types/keyv": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/minimatch": {
       "version": "3.0.4",
@@ -4007,15 +3748,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4638,12 +4370,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -5298,60 +5024,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true
-    },
-    "cacheable-request": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-      "dev": true,
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "http-cache-semantics": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-          "dev": true
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -5443,26 +5115,6 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
           "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
           "optional": true
-        }
-      }
-    },
-    "carbon-components": {
-      "version": "10.36.0",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.36.0.tgz",
-      "integrity": "sha512-k+UR+Whz/qXbev2RT9JjV+QbkSKcHrLNF25bEpr3KZHmpCGhwGz5mVyv0ohZ4B6rKkpuvlgYfLsANL0yQX77zA==",
-      "dev": true,
-      "requires": {
-        "@carbon/telemetry": "0.0.0-alpha.6",
-        "flatpickr": "4.6.1",
-        "lodash.debounce": "^4.0.8",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "flatpickr": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.1.tgz",
-          "integrity": "sha512-3ULSxbXmcMIRzer/2jLNweoqHpwDvsjEawO2FUd9UFR8uPwLM+LruZcPDpuZStcEgbQKhuFOfXo4nYdGladSNw==",
-          "dev": true
         }
       }
     },
@@ -5717,15 +5369,6 @@
         "shallow-clone": "^3.0.0"
       }
     },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -5840,7 +5483,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -5848,8 +5490,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "color-string": {
       "version": "1.5.5",
@@ -5878,16 +5519,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
-    },
-    "colorspace": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
-      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
-      "dev": true,
-      "requires": {
-        "color": "3.0.x",
-        "text-hex": "1.0.x"
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -6777,23 +6408,6 @@
       "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
-    "decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^3.1.0"
-      },
-      "dependencies": {
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "dev": true
-        }
-      }
-    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -6842,12 +6456,6 @@
       "requires": {
         "clone": "^1.0.2"
       }
-    },
-    "defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -7211,12 +6819,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
-    },
-    "enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "dev": true
     },
     "encodeurl": {
@@ -7931,12 +7533,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
-    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -7960,12 +7556,6 @@
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
-    },
-    "fecha": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
-      "dev": true
     },
     "fflate": {
       "version": "0.4.8",
@@ -8149,12 +7739,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
-    },
-    "fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "dev": true
     },
     "follow-redirects": {
       "version": "1.14.1",
@@ -8771,16 +8355,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
-      "requires": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
       }
     },
     "https-browserify": {
@@ -9859,12 +9433,6 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-      "dev": true
-    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -9893,12 +9461,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
-    },
-    "json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -10256,15 +9818,6 @@
         "source-map-support": "^0.5.5"
       }
     },
-    "keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.1"
-      }
-    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -10281,12 +9834,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
-      "dev": true
-    },
-    "kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "dev": true
     },
     "less": {
@@ -10820,12 +10367,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11009,47 +10550,11 @@
         "streamroller": "^2.2.4"
       }
     },
-    "logform": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
-      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
-      "dev": true,
-      "requires": {
-        "colors": "^1.2.1",
-        "fast-safe-stringify": "^2.0.4",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "triple-beam": "^1.3.0"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
-      }
-    },
     "loglevel": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -11378,12 +10883,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "mini-css-extract-plugin": {
@@ -13100,12 +12599,6 @@
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
     },
-    "normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-      "dev": true
-    },
     "npm-bundled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -13388,15 +12881,6 @@
         "wrappy": "1"
       }
     },
-    "one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dev": true,
-      "requires": {
-        "fn.name": "1.x.x"
-      }
-    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -13553,12 +13037,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true
-    },
-    "p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true
     },
     "p-finally": {
@@ -14892,12 +14370,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true
-    },
     "quote-stream": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
@@ -15259,12 +14731,6 @@
         "path-parse": "^1.0.6"
       }
     },
-    "resolve-alpn": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.1.2.tgz",
-      "integrity": "sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==",
-      "dev": true
-    },
     "resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -15348,23 +14814,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        }
-      }
-    },
-    "responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
         }
       }
     },
@@ -15936,7 +15385,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -15944,8 +15392,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -16507,12 +15954,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "dev": true
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
       "dev": true
     },
     "stackblur-canvas": {
@@ -17152,12 +16593,6 @@
         }
       }
     },
-    "text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "dev": true
-    },
     "text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -17321,12 +16756,6 @@
         "mergesort": "0.0.1"
       }
     },
-    "triple-beam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-      "dev": true
-    },
     "ts-node": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
@@ -17485,15 +16914,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "typescript": {
       "version": "4.0.7",
@@ -17879,15 +17299,6 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "watchpack": {
       "version": "1.7.5",
@@ -18805,81 +18216,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "winston": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
-      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
-      "dev": true,
-      "requires": {
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.1.0",
-        "is-stream": "^2.0.0",
-        "logform": "^2.2.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "winston-transport": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.3.7",
-        "triple-beam": "^1.2.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "e2e": "ng e2e"
   },
   "peerDependencies": {
-    "carbon-components": "10.x"
+    "@carbon/styles": "1.x"
   },
   "dependencies": {
     "@angular-devkit/core": "^10.2.3",
@@ -26,6 +26,7 @@
     "@angular/platform-browser": "^11.2.14",
     "@angular/platform-browser-dynamic": "^11.2.14",
     "@angular/router": "^11.2.14",
+    "@carbon/styles": "^1.9.0",
     "@ng-select/ng-select": "^6.1.0",
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
@@ -57,7 +58,6 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",
-    "carbon-components": "^10.36.0",
     "codelyzer": "^6.0.0",
     "husky": "^4.3.0",
     "jasmine-core": "~3.6.0",

--- a/projects/ngx-formentry/package.json
+++ b/projects/ngx-formentry/package.json
@@ -19,7 +19,7 @@
     "shelljs": "^0.7.0",
     "slick-carousel": "^1.6.0",
     "tree-model": "^1.0.5",
-    "carbon-components": "^10.36.0",
+    "@carbon/styles": "^1.9.0",
     "ngx-file-uploader": "^0.0.18",
     "@angular-extensions/elements": "^12.6.0"
   }

--- a/projects/ngx-formentry/src/change-tracking/sample-form/sample-form.component.html
+++ b/projects/ngx-formentry/src/change-tracking/sample-form/sample-form.component.html
@@ -58,11 +58,11 @@
       >
     </div>
     <div class="form-row">
-      <button class="bx--btn bx--btn--primary" type="submit" [disabled]="!form.valid">Save</button>
-      <button class="bx--btn bx--btn--secondary" type="button" (click)="setControlOneValue()">
+      <button class="cds--btn cds--btn--primary" type="submit" [disabled]="!form.valid">Save</button>
+      <button class="cds--btn cds--btn--secondary" type="button" (click)="setControlOneValue()">
         change value 1
       </button>
-      <button class="bx--btn bx--btn--danger" type="button" (click)="removeControlNine()">
+      <button class="cds--btn cds--btn--danger" type="button" (click)="removeControlNine()">
         remove control 9
       </button>
     </div>

--- a/projects/ngx-formentry/src/components/appointments-overview/appointments-overview.component.html
+++ b/projects/ngx-formentry/src/components/appointments-overview/appointments-overview.component.html
@@ -1,24 +1,24 @@
 <div *ngIf="showAppointments" class="container">
   <div *ngIf="loadingAppointments">
     <span *ngIf="!appointmentsLoaded && errorLoadingAppointments">Error checking appointments</span>
-    <div *ngIf="loadingAppointments" class="bx--inline-loading" aria-live="assertive">
-      <div class="bx--inline-loading__animation">
+    <div *ngIf="loadingAppointments" class="cds--inline-loading" aria-live="assertive">
+      <div class="cds--inline-loading__animation">
         <div aria-atomic="true" aria-labelledby="loading-id-2" aria-live="assertive"
-          class="bx--loading bx--loading--small">
-          <label id="loading-id-2" class="bx--visually-hidden">Active loading indicator</label><svg
-            class="bx--loading__svg" viewBox="0 0 100 100">
+          class="cds--loading cds--loading--small">
+          <label id="loading-id-2" class="cds--visually-hidden">Active loading indicator</label><svg
+            class="cds--loading__svg" viewBox="0 0 100 100">
             <title>Active loading indicator</title>
-            <circle class="bx--loading__background" cx="50%" cy="50%" r="44"></circle>
-            <circle class="bx--loading__stroke" cx="50%" cy="50%" r="44"></circle>
+            <circle class="cds--loading__background" cx="50%" cy="50%" r="44"></circle>
+            <circle class="cds--loading__stroke" cx="50%" cy="50%" r="44"></circle>
           </svg>
         </div>
       </div>
-      <div class="bx--inline-loading__text">Loading...</div>
+      <div class="cds--inline-loading__text">Loading...</div>
     </div>
   </div>
 
-  <div class="bx--data-table-content" *ngIf="appointmentsLoaded && !errorLoadingAppointments">
-    <table class="bx--data-table bx--data-table--no-border">
+  <div class="cds--data-table-content" *ngIf="appointmentsLoaded && !errorLoadingAppointments">
+    <table class="cds--data-table cds--data-table--no-border">
       <thead>
         <tr>
           <th *ngFor="let appointment of appointments" scope="col" [ngClass]="{ active: appointment.date === today }">

--- a/projects/ngx-formentry/src/components/check-box/checkbox.component.html
+++ b/projects/ngx-formentry/src/components/check-box/checkbox.component.html
@@ -1,8 +1,8 @@
-<fieldset class="bx--fieldset">
-  <div class="bx--form-item bx--checkbox-wrapper" *ngFor="let option of options; let i = index">
-    <input type="checkbox" class="bx--checkbox" [id]="i + id" [checked]="option.checked" (change)="selectOpt(option, $event)" [value]="option.value">
-    <label [for]="i + id" class="bx--checkbox-label">
-      <span class="bx--checkbox-label-text">{{ option.label }}</span>
+<fieldset class="cds--fieldset">
+  <div class="cds--form-item cds--checkbox-wrapper" *ngFor="let option of options; let i = index">
+    <input type="checkbox" class="cds--checkbox" [id]="i + id" [checked]="option.checked" (change)="selectOpt(option, $event)" [value]="option.value">
+    <label [for]="i + id" class="cds--checkbox-label">
+      <span class="cds--checkbox-label-text">{{ option.label }}</span>
     </label>
   </div>
 </fieldset>

--- a/projects/ngx-formentry/src/components/input/input.directive.ts
+++ b/projects/ngx-formentry/src/components/input/input.directive.ts
@@ -26,17 +26,17 @@ export class TextInput {
      */
     @Input() size: "sm" | "md" | "xl" = "md";
 
-    @HostBinding("class.bx--text-input") inputClass = true;
-    @HostBinding("class.bx--text-input--xl") get isSizeXl() {
+    @HostBinding("class.cds--text-input") inputClass = true;
+    @HostBinding("class.cds--text-input--xl") get isSizeXl() {
         return this.size === "xl";
     }
-    @HostBinding("class.bx--text-input--sm") get isSizeSm() {
+    @HostBinding("class.cds--text-input--sm") get isSizeSm() {
         return this.size === "sm";
     }
-    @HostBinding("class.bx--text-input--invalid") @Input() invalid = false;
-    @HostBinding("class.bx--text-input__field-wrapper--warning") @Input() warn = false;
-    @HostBinding("class.bx--skeleton") @Input() skeleton = false;
-    @HostBinding("class.bx--text-input--light") get isLightTheme() {
+    @HostBinding("class.cds--text-input--invalid") @Input() invalid = false;
+    @HostBinding("class.cds--text-input__field-wrapper--warning") @Input() warn = false;
+    @HostBinding("class.cds--skeleton") @Input() skeleton = false;
+    @HostBinding("class.cds--text-input--light") get isLightTheme() {
         return this.theme === "light";
     }
 }

--- a/projects/ngx-formentry/src/components/input/label.component.ts
+++ b/projects/ngx-formentry/src/components/input/label.component.ts
@@ -41,31 +41,31 @@ import { TextArea } from "./text-area.directive";
         <label
             [for]="labelInputID"
             [attr.aria-label]="ariaLabel"
-            class="bx--label"
+            class="cds--label"
             [ngClass]="{
-                'bx--skeleton': skeleton
+                'cds--skeleton': skeleton
             }">
             <ng-content></ng-content>
         </label>
         <div
             [class]="wrapperClass"
             [ngClass]="{
-                'bx--text-input__field-wrapper--warning': warn
+                'cds--text-input__field-wrapper--warning': warn
             }"
             [attr.data-invalid]="(invalid ? true : null)"
             #wrapper>
-            <svg *ngIf="invalid"focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="bx--text-input__invalid-icon" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8,1C4.2,1,1,4.2,1,8s3.2,7,7,7s7-3.1,7-7S11.9,1,8,1z M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2    c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"></path><path d="M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8    c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z" data-icon-path="inner-path" opacity="0"></path></svg>
+            <svg *ngIf="invalid"focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="cds--text-input__invalid-icon" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8,1C4.2,1,1,4.2,1,8s3.2,7,7,7s7-3.1,7-7S11.9,1,8,1z M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2    c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"></path><path d="M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8    c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z" data-icon-path="inner-path" opacity="0"></path></svg>
             <ng-content select="input,textarea,div"></ng-content>
         </div>
-        <div *ngIf="!skeleton && helperText && !invalid && !warn" class="bx--form__helper-text">
+        <div *ngIf="!skeleton && helperText && !invalid && !warn" class="cds--form__helper-text">
             <ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
             <ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
         </div>
-        <div *ngIf="!warn && invalid" class="bx--form-requirement">
+        <div *ngIf="!warn && invalid" class="cds--form-requirement">
             <ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
             <ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
         </div>
-        <div *ngIf="!invalid && warn" class="bx--form-requirement">
+        <div *ngIf="!invalid && warn" class="cds--form-requirement">
             <ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
             <ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
         </div>
@@ -79,7 +79,7 @@ export class Label implements AfterContentInit, AfterViewInit {
     /**
      * The class of the wrapper
      */
-    wrapperClass = "bx--text-input__field-wrapper";
+    wrapperClass = "cds--text-input__field-wrapper";
     /**
      * The id of the input item associated with the `Label`. This value is also used to associate the `Label` with
      * its input counterpart through the 'for' attribute.
@@ -125,7 +125,7 @@ export class Label implements AfterContentInit, AfterViewInit {
     // @ts-ignore
     @ContentChild(TextArea, { static: false }) textArea: TextArea;
 
-    @HostBinding("class.bx--form-item") labelClass = true;
+    @HostBinding("class.cds--form-item") labelClass = true;
 
     /**
      * Creates an instance of Label.
@@ -139,7 +139,7 @@ export class Label implements AfterContentInit, AfterViewInit {
      */
     ngAfterContentInit() {
         if (this.textArea) {
-            this.wrapperClass = "bx--text-area__wrapper";
+            this.wrapperClass = "cds--text-area__wrapper";
         }
     }
 

--- a/projects/ngx-formentry/src/components/input/text-area.directive.ts
+++ b/projects/ngx-formentry/src/components/input/text-area.directive.ts
@@ -21,10 +21,10 @@ export class TextArea {
      */
     @Input() theme: "light" | "dark" = "dark";
 
-    @HostBinding("class.bx--text-area") baseClass = true;
-    @HostBinding("class.bx--text-area--invalid") @Input() invalid = false;
-    @HostBinding("class.bx--skeleton") @Input() skeleton = false;
-    @HostBinding("class.bx--text-area--light") get isLightTheme() {
+    @HostBinding("class.cds--text-area") baseClass = true;
+    @HostBinding("class.cds--text-area--invalid") @Input() invalid = false;
+    @HostBinding("class.cds--skeleton") @Input() skeleton = false;
+    @HostBinding("class.cds--text-area--light") get isLightTheme() {
         return this.theme === "light";
     }
 }

--- a/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
+++ b/projects/ngx-formentry/src/components/ngx-datetime-picker/ngx-datetime-picker.html
@@ -2,18 +2,18 @@
   <div
     data-date-picker
     data-date-picker-type="single"
-    class="bx--date-picker bx--date-picker--single bx--date-picker--light"
+    class="cds--date-picker cds--date-picker--single cds--date-picker--light"
     [ngClass]="{
-    'bx--date-picker--light': theme === 'light'
+    'cds--date-picker--light': theme === 'light'
 }"
   >
-    <div class="bx--date-picker-container fill">
-      <div class="bx--date-picker-input__wrapper">
+    <div class="cds--date-picker-container fill">
+      <div class="cds--date-picker-input__wrapper">
         <input
           [disabled]="isDisabled"
           (dateTimeChange)="onInput($event)"
           type="text"
-          class="bx--date-picker__input fill"
+          class="cds--date-picker__input fill"
           [id]="id"
           [value]="value"
           [owlDateTime]="dt1"
@@ -28,7 +28,7 @@
           style="will-change: transform"
           xmlns="http://www.w3.org/2000/svg"
           data-date-picker-icon="true"
-          class="bx--date-picker__icon"
+          class="cds--date-picker__icon"
           width="16"
           height="16"
           viewBox="0 0 16 16"
@@ -44,17 +44,17 @@
 
   <div
     *ngIf="showWeeks"
-    class="bx--select some-class week-select-wrapper"
-    [ngClass]="{'bx--select--light': theme === 'light'}"
+    class="cds--select some-class week-select-wrapper"
+    [ngClass]="{'cds--select--light': theme === 'light'}"
   >
-    <div class="bx--select-input__wrapper">
+    <div class="cds--select-input__wrapper">
       <select
         (change)="onWeeksSelected($event.target.value)"
         id="select-1"
-        class="bx--select-input"
+        class="cds--select-input"
       >
         <option
-          class="bx--select-option"
+          class="cds--select-option"
           value="placeholder-item"
           disabled=""
           hidden=""
@@ -63,7 +63,7 @@
           Select Weeks
         </option>
         <option
-          class="bx--select-option"
+          class="cds--select-option"
           [value]="week"
           *ngFor="let week of weeks"
         >
@@ -79,7 +79,7 @@
         height="16"
         viewBox="0 0 16 16"
         aria-hidden="true"
-        class="bx--select__arrow"
+        class="cds--select__arrow"
       >
         <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
       </svg>

--- a/projects/ngx-formentry/src/components/number-input/number-input.component.html
+++ b/projects/ngx-formentry/src/components/number-input/number-input.component.html
@@ -1,48 +1,48 @@
-<div data-numberinput [attr.data-invalid]="invalid ? true : null" class="bx--number" [ngClass]="{
-      'bx--number--light': theme === 'light',
-      'bx--number--nolabel': !label,
-      'bx--number--helpertext': helperText,
-      'bx--skeleton': skeleton,
-      'bx--number--sm': size === 'sm',
-      'bx--number--xl': size === 'xl'
+<div data-numberinput [attr.data-invalid]="invalid ? true : null" class="cds--number" [ngClass]="{
+      'cds--number--light': theme === 'light',
+      'cds--number--nolabel': !label,
+      'cds--number--helpertext': helperText,
+      'cds--skeleton': skeleton,
+      'cds--number--sm': size === 'sm',
+      'cds--number--xl': size === 'xl'
     }">
-  <div class="bx--number__input-wrapper" [ngClass]="{
-        'bx--number__input-wrapper--warning': warn
+  <div class="cds--number__input-wrapper" [ngClass]="{
+        'cds--number__input-wrapper--warning': warn
       }">
     <input type="number" [id]="id" [value]="value" [attr.min]="min" [attr.max]="max" [attr.step]="step"
       [disabled]="disabled" [required]="required" (input)="onNumberInputChange($event)" />
-    <div class="bx--number__controls">
-      <button type="button" class="bx--number__control-btn down-icon" (click)="onDecrement()" title="Decrement number"
+    <div class="cds--number__controls">
+      <button type="button" class="cds--number__control-btn down-icon" (click)="onDecrement()" title="Decrement number"
         [attr.aria-label]="decrementLabel" tabindex="-1">
         <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg"
           fill="currentColor" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true" class="down-icon">
           <path d="M8 15H24V17H8z"></path>
         </svg>
       </button>
-      <div class="bx--number__rule-divider"></div>
-      <button type="button" class="bx--number__control-btn up-icon" (click)="onIncrement()" title="Increment number"
+      <div class="cds--number__rule-divider"></div>
+      <button type="button" class="cds--number__control-btn up-icon" (click)="onIncrement()" title="Increment number"
         [attr.aria-label]="incrementLabel" tabindex="-1">
         <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg"
           fill="currentColor" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true" class="up-icon">
           <path d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"></path>
         </svg>
       </button>
-      <div class="bx--number__rule-divider"></div>
+      <div class="cds--number__rule-divider"></div>
     </div>
   </div>
-  <div *ngIf="helperText && !invalid && !warn" class="bx--form__helper-text">
+  <div *ngIf="helperText && !invalid && !warn" class="cds--form__helper-text">
     <ng-container *ngIf="!isTemplate(helperText)">{{
       helperText
       }}</ng-container>
     <ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
   </div>
-  <div *ngIf="!warn && invalid" class="bx--form-requirement">
+  <div *ngIf="!warn && invalid" class="cds--form-requirement">
     <ng-container *ngIf="!isTemplate(invalidText)">{{
       invalidText
       }}</ng-container>
     <ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
   </div>
-  <div *ngIf="!invalid && warn" class="bx--form-requirement">
+  <div *ngIf="!invalid && warn" class="cds--form-requirement">
     <ng-container *ngIf="!isTemplate(warnText)">{{ warnText }}</ng-container>
     <ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
   </div>

--- a/projects/ngx-formentry/src/components/select/optgroup.directive.ts
+++ b/projects/ngx-formentry/src/components/select/optgroup.directive.ts
@@ -6,5 +6,5 @@ import { Directive, HostBinding } from "@angular/core";
 	selector: "optgroup"
 })
 export class OptGroup {
-   @HostBinding("class") inputClass = "bx--select-optgroup";
+   @HostBinding("class") inputClass = "cds--select-optgroup";
 }

--- a/projects/ngx-formentry/src/components/select/option.directive.ts
+++ b/projects/ngx-formentry/src/components/select/option.directive.ts
@@ -6,5 +6,5 @@ import { Directive, HostBinding } from "@angular/core";
     selector: "option"
 })
 export class Option {
-    @HostBinding("class") inputClass = "bx--select-option";
+    @HostBinding("class") inputClass = "cds--select-option";
 }

--- a/projects/ngx-formentry/src/components/select/select.component.spec.ts
+++ b/projects/ngx-formentry/src/components/select/select.component.spec.ts
@@ -43,7 +43,7 @@ describe("Select", () => {
         fixture = TestBed.createComponent(SelectTest);
         wrapper = fixture.componentInstance;
         fixture.detectChanges();
-        const de = fixture.debugElement.query(By.css(".bx--select-input"));
+        const de = fixture.debugElement.query(By.css(".cds--select-input"));
         spyOn(wrapper, "onChange").and.callThrough();
         de.triggerEventHandler("change", {target: {value: "option1"}});
         fixture.detectChanges();
@@ -61,7 +61,7 @@ describe("Select", () => {
         }).createComponent(SelectTest);
         fixture.detectChanges();
         element = fixture.debugElement.query(By.css("ibm-select")).nativeElement;
-        expect(element.querySelector(".bx--label").textContent).toEqual("test");
+        expect(element.querySelector(".cds--label").textContent).toEqual("test");
     });
 
     it("should set helperText to test", () => {
@@ -72,7 +72,7 @@ describe("Select", () => {
         }).createComponent(SelectTest);
         fixture.detectChanges();
         element = fixture.debugElement.query(By.css("ibm-select")).nativeElement;
-        expect(element.querySelector(".bx--form__helper-text").textContent).toEqual("test");
+        expect(element.querySelector(".cds--form__helper-text").textContent).toEqual("test");
     });
 
     it("should set display to inline", () => {
@@ -83,7 +83,7 @@ describe("Select", () => {
         }).createComponent(SelectTest);
         fixture.detectChanges();
         element = fixture.debugElement.query(By.css("ibm-select")).nativeElement;
-        expect(element.querySelector(".bx--select--inline")).toBeTruthy();
+        expect(element.querySelector(".cds--select--inline")).toBeTruthy();
     });
 
     it("should set option to disabled", () => {
@@ -108,11 +108,11 @@ describe("Select", () => {
         }).createComponent(SelectTest);
         fixture.detectChanges();
         element = fixture.debugElement.query(By.css("ibm-select")).nativeElement;
-        expect(element.querySelector(".bx--select__invalid-icon")).toBeTruthy();
-        expect(element.querySelector(".bx--form-requirement").textContent).toEqual("test");
+        expect(element.querySelector(".cds--select__invalid-icon")).toBeTruthy();
+        expect(element.querySelector(".cds--form-requirement").textContent).toEqual("test");
     });
 
-    it("should set class bx--skeleton", () => {
+    it("should set class cds--skeleton", () => {
         fixture = TestBed.overrideComponent(SelectTest, {
             set: {
                 template: `<ibm-select [skeleton]=true></ibm-select>`
@@ -120,6 +120,6 @@ describe("Select", () => {
         }).createComponent(SelectTest);
         fixture.detectChanges();
         element = fixture.debugElement.query(By.css("ibm-select")).nativeElement;
-        expect(element.querySelector(".bx--skeleton")).toBeTruthy();
+        expect(element.querySelector(".cds--skeleton")).toBeTruthy();
     });
 });

--- a/projects/ngx-formentry/src/components/select/select.component.ts
+++ b/projects/ngx-formentry/src/components/select/select.component.ts
@@ -33,30 +33,30 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 @Component({
     selector: "ibm-select",
     template: `
-        <div class="bx--form-item">
+        <div class="cds--form-item">
             <ng-template [ngIf]="skeleton">
-                <div *ngIf="label" class="bx--label bx--skeleton"></div>
-                <div class="bx--select bx--skeleton"></div>
+                <div *ngIf="label" class="cds--label cds--skeleton"></div>
+                <div class="cds--select cds--skeleton"></div>
             </ng-template>
             <div
                 *ngIf="!skeleton"
-                class="bx--select"
+                class="cds--select"
                 [ngClass]="{
-                    'bx--select--inline': display === 'inline',
-                    'bx--select--light': theme === 'light',
-                    'bx--select--invalid': invalid,
-                    'bx--select--warning': warn,
-                    'bx--select--disabled': disabled
+                    'cds--select--inline': display === 'inline',
+                    'cds--select--light': theme === 'light',
+                    'cds--select--invalid': invalid,
+                    'cds--select--warning': warn,
+                    'cds--select--disabled': disabled
                 }">
-                <label *ngIf="label" [for]="id" class="bx--label">
+                <label *ngIf="label" [for]="id" class="cds--label">
                     <ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
                     <ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
                 </label>
-                <div *ngIf="helperText" class="bx--form__helper-text">
+                <div *ngIf="helperText" class="cds--form__helper-text">
                     <ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
                     <ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
                 </div>
-                <div *ngIf="display === 'inline'; else noInline" class="bx--select-input--inline__wrapper">
+                <div *ngIf="display === 'inline'; else noInline" class="cds--select-input--inline__wrapper">
                     <ng-container *ngTemplateOutlet="noInline"></ng-container>
                 </div>
             </div>
@@ -64,7 +64,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
         <!-- select element: dynamically projected based on 'display' variant -->
         <ng-template #noInline>
-            <div class="bx--select-input__wrapper extend" [attr.data-invalid]="(invalid ? true : null)">
+            <div class="cds--select-input__wrapper extend" [attr.data-invalid]="(invalid ? true : null)">
                 <select
                     #select
                     [attr.id]="id"
@@ -72,10 +72,10 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
                     [disabled]="disabled"
                     (change)="onChange($event)"
                     [attr.aria-invalid]="invalid ? 'true' : null"
-                    class="bx--select-input"
+                    class="cds--select-input"
                     [ngClass]="{
-                        'bx--select-input--xl': size === 'xl',
-                        'bx--select-input--sm': size === 'sm'
+                        'cds--select-input--xl': size === 'xl',
+                        'cds--select-input--sm': size === 'sm'
                     }">
                     <ng-content></ng-content>
                 </select>
@@ -84,34 +84,34 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
                     preserveAspectRatio="xMidYMid meet"
                     style="will-change: transform;"
                     xmlns="http://www.w3.org/2000/svg"
-                    class="bx--select__arrow"
+                    class="cds--select__arrow"
                     width="16"
                     height="16"
                     viewBox="0 0 16 16"
                     aria-hidden="true">
                     <path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
                 </svg>
-                <svg *ngIf="invalid"focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="bx--text-input__invalid-icon" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8,1C4.2,1,1,4.2,1,8s3.2,7,7,7s7-3.1,7-7S11.9,1,8,1z M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2    c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"></path><path d="M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8    c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z" data-icon-path="inner-path" opacity="0"></path></svg>
+                <svg *ngIf="invalid"focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" class="cds--text-input__invalid-icon" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path d="M8,1C4.2,1,1,4.2,1,8s3.2,7,7,7s7-3.1,7-7S11.9,1,8,1z M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2    c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z"></path><path d="M7.5,4h1v5h-1C7.5,9,7.5,4,7.5,4z M8,12.2c-0.4,0-0.8-0.4-0.8-0.8s0.3-0.8,0.8-0.8    c0.4,0,0.8,0.4,0.8,0.8S8.4,12.2,8,12.2z" data-icon-path="inner-path" opacity="0"></path></svg>
             </div>
-            <div *ngIf="invalid && invalidText && !warn" role="alert" class="bx--form-requirement" aria-live="polite">
+            <div *ngIf="invalid && invalidText && !warn" role="alert" class="cds--form-requirement" aria-live="polite">
                 <ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
                 <ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
             </div>
-            <div *ngIf="!invalid && warn" class="bx--form-requirement">
+            <div *ngIf="!invalid && warn" class="cds--form-requirement">
                 <ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
                 <ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
             </div>
         </ng-template>
     `,
     styles: [`
-        .bx--select--inline .bx--form__helper-text {
+        .cds--select--inline .cds--form__helper-text {
             order: 4;
         }
 
-        .bx--select--inline:not(.bx--select--invalid) .bx--form__helper-text {
+        .cds--select--inline:not(.cds--select--invalid) .cds--form__helper-text {
             margin-top: 0;
         }
-        .bx--select-input__wrapper{
+        .cds--select-input__wrapper{
             min-width: 16rem;
         }
     `],

--- a/projects/ngx-formentry/src/form-entry/error-renderer/error-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/error-renderer/error-renderer.component.html
@@ -1,17 +1,17 @@
 <div *ngIf="showErrors()" class="container">
   <div data-notification *ngFor="let errorNode of errorNodes"
-    class="bx--inline-notification bx--inline-notification--error bx--inline-notification--low-contrast pointer" role="alert"
+    class="cds--inline-notification cds--inline-notification--error cds--inline-notification--low-contrast pointer" role="alert"
     (click)="announceErrorField(errorNode)">
-    <div class="bx--inline-notification__details">
-      <div class="bx--inline-notification__text-wrapper">
-        <p class="bx--inline-notification__title">{{ errorNode.question.label }}</p>
-        <p class="bx--inline-notification__subtitle">{{ getControlError(errorNode) }}</p>
+    <div class="cds--inline-notification__details">
+      <div class="cds--inline-notification__text-wrapper">
+        <p class="cds--inline-notification__title">{{ errorNode.question.label }}</p>
+        <p class="cds--inline-notification__subtitle">{{ getControlError(errorNode) }}</p>
       </div>
     </div>
-    <button tabindex="0" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost"
+    <button tabindex="0" class="cds--inline-notification__action-button cds--btn cds--btn--sm cds--btn--ghost"
       type="button">Fix</button>
     <svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;"
-      xmlns="http://www.w3.org/2000/svg" class="bx--inline-notification__icon" width="20" height="20"
+      xmlns="http://www.w3.org/2000/svg" class="cds--inline-notification__icon" width="20" height="20"
       viewBox="0 0 20 20" aria-hidden="true">
       <path d="M10,1c-5,0-9,4-9,9s4,9,9,9s9-4,9-9S15,1,10,1z M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z"></path>
       <path d="M13.5,14.5l-8-8l1-1l8,8L13.5,14.5z" data-icon-path="inner-path" opacity="0"></path>

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -33,18 +33,18 @@
 </div>
 <div *ngIf="node.question.renderingType === 'section' && checkSection(node)">
   <div
-    class="bx--accordion__item"
-    [ngClass]="{ 'bx--accordion__item--active': !isCollapsed }"
+    class="cds--accordion__item"
+    [ngClass]="{ 'cds--accordion__item--active': !isCollapsed }"
   >
     <button
-      class="bx--accordion__heading"
+      class="cds--accordion__heading"
       type="button"
       [attr.aria-expanded]="isCollapsed ? 'false' : 'true'"
       aria-controls="accordion-item-0"
       (click)="isCollapsed = !isCollapsed"
     >
       <svg
-        class="bx--accordion__arrow"
+        class="cds--accordion__arrow"
         ibmIcon="chevron--right"
         size="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -57,7 +57,7 @@
       >
         <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
       </svg>
-      <p class="bx--accordion__title">
+      <p class="cds--accordion__title">
         {{ node.question.label }}
       </p>
     </button>
@@ -69,7 +69,7 @@
       >
       </app-custom-component-wrapper>
       <div
-        class="bx--accordion__content accordion-content-override"
+        class="cds--accordion__content accordion-content-override"
         [ngClass]="{
           'accordion-content-dark': theme === 'light'
         }"
@@ -107,7 +107,7 @@
     [componentConfigs]="node.question.componentConfigs"
   >
   </app-custom-component-wrapper>
-  <div class="bx--form-item">
+  <div class="cds--form-item">
     <!--LEAF CONTROL-->
     <div class="question-area">
       <a
@@ -127,7 +127,7 @@
       <label
         *ngIf="node.question.label"
         [style.color]="hasErrors() ? 'red' : ''"
-        class="bx--label"
+        class="cds--label"
         [attr.for]="node.question.key"
       >
         {{ node.question.required ? '*' : '' }}
@@ -176,12 +176,12 @@
             [theme]="theme"
             ibmTextArea
             [ngClass]="{
-              'bx--text-area--light': theme === 'light',
-              'bx--text-area--invalid': !node.control.valid
+              'cds--text-area--light': theme === 'light',
+              'cds--text-area--invalid': !node.control.valid
             }"
             [placeholder]="node.question.placeholder"
             [rows]="node.question.rows"
-            class="bx--text-area"
+            class="cds--text-area"
             *ngSwitchCase="'textarea'"
             [formControlName]="node.question.key"
             [id]="node.question.key + 'id'"
@@ -250,7 +250,7 @@
 
           <input
             [theme]="theme"
-            class="bx--text-input"
+            class="cds--text-input"
             ibmText
             *ngSwitchDefault
             [formControlName]="node.question.key"
@@ -322,7 +322,7 @@
                   type="button"
                   [node]="node"
                   [name]="'historyValue'"
-                  class="bx--btn bx--btn--primary bx--btn--sm col-xs-3"
+                  class="cds--btn cds--btn--primary cds--btn--sm col-xs-3"
                 >
                   Use Value
                 </button>
@@ -384,7 +384,7 @@
             <div>{{ child.orderNumber }}</div>
             <button
               type="button "
-              class="bx--btn bx--btn--danger bx--btn--sm"
+              class="cds--btn cds--btn--danger cds--btn--sm"
               (click)="node.removeAt(i)"
             >
               Remove
@@ -413,7 +413,7 @@
             ></form-renderer>
             <button
               type="button "
-              class="bx--btn bx--btn--danger bx--btn--sm"
+              class="cds--btn cds--btn--danger cds--btn--sm"
               (click)="node.removeAt(i)"
             >
               Remove
@@ -433,7 +433,7 @@
       </div>
       <button
         type="button"
-        class="bx--btn bx--btn--primary"
+        class="cds--btn cds--btn--primary"
         (click)="node.createChildNode()"
       >
         Add

--- a/projects/ngx-formentry/styles/ngx-formentry.css
+++ b/projects/ngx-formentry/styles/ngx-formentry.css
@@ -174,7 +174,7 @@
 }
 
 .ng-select .ng-arrow-wrapper .ng-arrow::after{
-	content: url("data:image/svg+xml;charset=UTF-8, <svg  focusable='false' preserveAspectRatio='xMidYMid meet' xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' aria-hidden='true' class='bx--select__arrow' style='will-change: transform;'><path  d='M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z'></path></svg>");
+	content: url("data:image/svg+xml;charset=UTF-8, <svg  focusable='false' preserveAspectRatio='xMidYMid meet' xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' aria-hidden='true' class='cds--select__arrow' style='will-change: transform;'><path  d='M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z'></path></svg>");
 }
 
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,11 +3,11 @@
     <form-renderer [node]="form.rootNode" [labelMap]="labelMap"></form-renderer>
   </form>
 
-  <div class="bx--offset-md-2">
-    <button (click)="reset($event)" class="bx--btn bx--btn--secondary" type="button">
+  <div class="cds--offset-md-2">
+    <button (click)="reset($event)" class="cds--btn cds--btn--secondary" type="button">
       Cancel
     </button>
-    <button (click)="onSubmit($event)" class="bx--btn bx--btn--primary" type="button">
+    <button (click)="onSubmit($event)" class="cds--btn cds--btn--primary" type="button">
       Save
     </button>
   </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~carbon-components/css/carbon-components.css';
+@import '~@carbon/styles/css/styles.min.css';
 :root {
   --brand-01: #005d5d;
   --brand-02: #004144;
   --brand-03: #007d79;
+  --cds-field: #ffffff;
 }


### PR DESCRIPTION
### What does this PR do?

- As a result of migrating to Carbon 11, the styling for form-entry on patient-chart and fast-data-entry apps have broken. This PR fixes the styling issues to be compatible with Carbon 11.


### Screenshoot
![Peek 2022-08-19 13-39](https://user-images.githubusercontent.com/28008754/185602060-19bf5d20-a1d6-41b0-ab4e-33a31d8b6784.gif)

