### PR TITLE
O3 Allow radio buttons to be unelectable 

### DIFF
--- a/projects/ngx-formentry/src/components/radio-button/radio.component.html
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.html
@@ -1,7 +1,7 @@
 <fieldset class="bx--fieldset">
   <div *ngFor="let option of options; let i = index" class="bx--form-item bx--radio-wrapper">
     <label class="form-control no-border">
-      <input type="radio" [id]="id + '_' + i" name="id" [checked]="option.checked" [value]="option.value"  (click)="isOptionUnselectable ? selectOpt(option, $event) : selectUnselectOpt(option, $event)" />
+      <input type="radio" [id]="id + '_' + i" name="id" [checked]="option.checked" [value]="option.value"  (click)="allowRadioUnselect ? selectOpt(option, $event) : selectUnselectOpt(option, $event)" />
       {{ option.label }}
     </label>
   </div>

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.html
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.html
@@ -1,0 +1,9 @@
+<fieldset class="bx--fieldset">
+  <div *ngFor="let option of options; let i = index" class="bx--form-item bx--radio-wrapper">
+    <label class="form-control no-border">
+      <input type="radio" [id]="id + '_' + i" name="id" [checked]="option.checked" [value]="option.value"  (click)="isOptionUnselectable ? selectOpt(option, $event) : selectUnselectOpt(option, $event)" />
+      {{ option.label }}
+    </label>
+  </div>
+</fieldset>
+

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -1,0 +1,76 @@
+import {
+  Component,
+  Input,
+  forwardRef,
+  OnInit,
+  AfterViewInit
+} from '@angular/core';
+
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import * as _ from 'lodash';
+
+@Component({
+  selector: 'radio',
+  templateUrl: './radio.component.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => RadioButtonControlComponent),
+      multi: true
+    }
+  ]
+})
+export class RadioButtonControlComponent implements OnInit, AfterViewInit {
+  @Input() public id: String;
+  @Input() public selected: any;
+  @Input() public options: Array<any>;
+  @Input() public isOptionUnselectable: Boolean;
+
+  public ngOnInit() {
+    this.options = this.options.map((option) => {
+      if (this.selected == option.value) {
+        this.selected = option.value;
+        Object.assign(option, { checked: true });
+      }
+      return option;
+    });}
+
+  public ngAfterViewInit() {}
+
+  public writeValue(value: any) { }
+
+  public registerOnChange(fn: (_: any) => void) {
+    this.onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void) {
+    this.onTouched = fn;
+  }
+
+  public selectOpt(option, event) {
+    this.options.forEach(o => {
+      if (event.target.checked && o.value == option.value ){
+        this.selected = o.value;
+        Object.assign(o, { checked: true });
+      }else{
+        this.selected = null;
+        Object.assign(o, { checked: false });
+      }
+    })
+  }
+
+  public selectUnselectOpt(option, event) {
+    this.options.forEach(o => {
+      if(event.target.checked && this.selected == o.value && this.selected == option.value){
+        this.selected = null;
+        Object.assign(o, { checked: false });
+      } else if (event.target.checked && o.value == option.value ){
+        this.selected = o.value;
+        Object.assign(o, { checked: true });
+      }
+    })
+  }
+
+  private onChange = (change: any) => {};
+  private onTouched = () => {};
+}

--- a/projects/ngx-formentry/src/components/radio-button/radio.component.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.component.ts
@@ -24,7 +24,7 @@ export class RadioButtonControlComponent implements OnInit, AfterViewInit {
   @Input() public id: String;
   @Input() public selected: any;
   @Input() public options: Array<any>;
-  @Input() public isOptionUnselectable: Boolean;
+  @Input() public allowRadioUnselect: Boolean;
 
   public ngOnInit() {
     this.options = this.options.map((option) => {
@@ -33,11 +33,12 @@ export class RadioButtonControlComponent implements OnInit, AfterViewInit {
         Object.assign(option, { checked: true });
       }
       return option;
-    });}
+    });
+  }
 
   public ngAfterViewInit() {}
 
-  public writeValue(value: any) { }
+  public writeValue(value: any) {}
 
   public registerOnChange(fn: (_: any) => void) {
     this.onChange = fn;
@@ -48,27 +49,31 @@ export class RadioButtonControlComponent implements OnInit, AfterViewInit {
   }
 
   public selectOpt(option, event) {
-    this.options.forEach(o => {
-      if (event.target.checked && o.value == option.value ){
+    this.options.forEach((o) => {
+      if (event.target.checked && o.value == option.value) {
         this.selected = o.value;
         Object.assign(o, { checked: true });
-      }else{
+      } else {
         this.selected = null;
         Object.assign(o, { checked: false });
       }
-    })
+    });
   }
 
   public selectUnselectOpt(option, event) {
-    this.options.forEach(o => {
-      if(event.target.checked && this.selected == o.value && this.selected == option.value){
+    this.options.forEach((o) => {
+      if (
+        event.target.checked &&
+        this.selected == o.value &&
+        this.selected == option.value
+      ) {
         this.selected = null;
         Object.assign(o, { checked: false });
-      } else if (event.target.checked && o.value == option.value ){
+      } else if (event.target.checked && o.value == option.value) {
         this.selected = o.value;
         Object.assign(o, { checked: true });
       }
-    })
+    });
   }
 
   private onChange = (change: any) => {};

--- a/projects/ngx-formentry/src/components/radio-button/radio.module.ts
+++ b/projects/ngx-formentry/src/components/radio-button/radio.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { FormsModule } from '@angular/forms';
+import { RadioButtonControlComponent } from './radio.component';
+
+@NgModule({
+  declarations: [RadioButtonControlComponent],
+  exports: [RadioButtonControlComponent],
+  imports: [CommonModule, FormsModule]
+})
+export class RadioModule {}

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -45,7 +45,6 @@ import { CustomControlWrapperModule } from '../components/custom-control-wrapper
 import { LazyElementsModule } from '@angular-extensions/elements';
 import { CustomComponentWrapperModule } from '../components/custom-component-wrapper/custom-component-wrapper..module';
 
-
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   imports: [
@@ -106,4 +105,4 @@ import { CustomComponentWrapperModule } from '../components/custom-component-wra
     NgxDateTimePickerModule
   ]
 })
-export class FormEntryModule { }
+export class FormEntryModule {}

--- a/projects/ngx-formentry/src/form-entry/form-entry.module.ts
+++ b/projects/ngx-formentry/src/form-entry/form-entry.module.ts
@@ -36,6 +36,7 @@ import { ObsValueAdapter } from './value-adapters/obs.adapter';
 import { NgxRemoteSelectModule } from '../components/ngx-remote-select/ngx-remote-select.module';
 import { AppointmentsOverviewComponent } from '../components/appointments-overview/appointments-overview.component';
 import { CheckboxModule } from '../components/check-box/checkbox.module';
+import { RadioModule } from '../components/radio-button/radio.module';
 import { SharedModule } from '../shared.module';
 import { NgxTabSetModule } from '../components/ngx-tabset/modules/ngx-tabset.module';
 import { SelectModule as SelectModuleCarbon } from '../components/select/select.module';
@@ -59,6 +60,7 @@ import { CustomComponentWrapperModule } from '../components/custom-component-wra
     // NoopAnimationsModule,
     RemoteFileUploadModule,
     CheckboxModule,
+    RadioModule,
     NgxDateTimePickerModule,
     SharedModule,
     CustomControlWrapperModule,

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -236,8 +236,8 @@ export class QuestionFactory {
     question.label = schemaQuestion.label;
     question.key = schemaQuestion.id;
     question.extras = schemaQuestion;
-    question.isOptionUnselectable =
-      schemaQuestion.questionOptions.isOptionUnselectable;
+    question.allowRadioUnselect =
+      schemaQuestion.questionOptions.allowRadioUnselect;
     question.options = schemaQuestion.questionOptions.answers.map((obj) => {
       return {
         label: obj.label,

--- a/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
+++ b/projects/ngx-formentry/src/form-entry/form-factory/question.factory.ts
@@ -26,7 +26,8 @@ import { DummyDataSource } from '../data-sources/dummy-data-source';
 import { HistoricalHelperService } from '../helpers/historical-expression-helper-service';
 import { Form } from './form';
 import { CheckBoxQuestion } from '../question-models/models';
-import { Injectable } from "@angular/core";
+import { RadioButtonQuestion } from '../question-models/models';
+import { Injectable } from '@angular/core';
 import { CustomControlQuestion } from '../question-models/custom-control-question.model';
 
 @Injectable()
@@ -203,7 +204,40 @@ export class QuestionFactory {
     question.prefix = schemaQuestion.prefix;
     question.key = schemaQuestion.id;
     question.extras = schemaQuestion;
-    question.orientation = schemaQuestion.questionOptions.orientation;
+    question.options = schemaQuestion.questionOptions.answers.map((obj) => {
+      return {
+        label: obj.label,
+        value: obj.concept
+      };
+    });
+    question.options.splice(0, 0);
+
+    question.renderingType = schemaQuestion.questionOptions.rendering;
+    const mappings: any = {
+      label: 'label',
+      required: 'required',
+      id: 'key'
+    };
+    question.componentConfigs = schemaQuestion.componentConfigs || [];
+    this.copyProperties(mappings, schemaQuestion, question);
+    this.addDisableOrHideProperty(schemaQuestion, question);
+    this.addAlertProperty(schemaQuestion, question);
+    this.addHistoricalExpressions(schemaQuestion, question);
+    this.addCalculatorProperty(schemaQuestion, question);
+    return question;
+  }
+
+  toRadioButtonQuestion(schemaQuestion: any): RadioButtonQuestion {
+    const question = new RadioButtonQuestion({
+      options: [],
+      type: '',
+      key: ''
+    });
+    question.label = schemaQuestion.label;
+    question.key = schemaQuestion.id;
+    question.extras = schemaQuestion;
+    question.isOptionUnselectable =
+      schemaQuestion.questionOptions.isOptionUnselectable;
     question.options = schemaQuestion.questionOptions.answers.map((obj) => {
       return {
         label: obj.label,
@@ -770,7 +804,7 @@ export class QuestionFactory {
       case 'encounterProvider':
         return this.toEncounterProviderQuestion(schema);
       case 'radio':
-        return this.toCheckBoxQuestion(schema);
+        return this.toRadioButtonQuestion(schema);
       case 'checkbox':
         return this.toCheckBoxQuestion(schema);
       case 'encounterProvider':

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -261,22 +261,8 @@
           />
 
           <div *ngSwitchCase="'radio'">
-            <div
-              *ngFor="let o of node.question.options"
-              [ngClass]="{
-                'in-line': node.question.orientation === 'horizontal'
-              }"
-            >
-              <label class="form-control no-border">
-                <input
-                  type="radio"
-                  [formControlName]="node.question.key"
-                  [id]="node.question.key + 'id'"
-                  [value]="o.value"
-                />
-                {{ o.label }}
-              </label>
-            </div>
+            <radio [id]="node.question.key + 'id'" [formControlName]="node.question.key"
+              [options]="node.question.options" [selected]="node.control.value" [isOptionUnselectable]="node.question.isOptionUnselectable"></radio>
           </div>
 
           <div *ngSwitchCase="'checkbox'">

--- a/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
+++ b/projects/ngx-formentry/src/form-entry/form-renderer/form-renderer.component.html
@@ -262,7 +262,7 @@
 
           <div *ngSwitchCase="'radio'">
             <radio [id]="node.question.key + 'id'" [formControlName]="node.question.key"
-              [options]="node.question.options" [selected]="node.control.value" [isOptionUnselectable]="node.question.isOptionUnselectable"></radio>
+              [options]="node.question.options" [selected]="node.control.value" [allowRadioUnselect]="node.question.allowRadioUnselect"></radio>
           </div>
 
           <div *ngSwitchCase="'checkbox'">

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -27,4 +27,5 @@ export interface BaseOptions {
   rows?: any;
   showWeeksAdder?: any;
   datePickerFormat?: any;
+  isOptionUnselectable?: any;
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/base-options.ts
@@ -27,5 +27,5 @@ export interface BaseOptions {
   rows?: any;
   showWeeksAdder?: any;
   datePickerFormat?: any;
-  isOptionUnselectable?: any;
+  allowRadioUnselect?: any;
 }

--- a/projects/ngx-formentry/src/form-entry/question-models/interfaces/radio-button-options.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/interfaces/radio-button-options.ts
@@ -1,0 +1,5 @@
+import { BaseOptions } from '../interfaces/base-options';
+
+export interface RadioButtonOptions extends BaseOptions {
+  options: { key: string; value: string }[];
+}

--- a/projects/ngx-formentry/src/form-entry/question-models/models.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/models.ts
@@ -14,3 +14,4 @@ export { RepeatingQuestion } from '../question-models/repeating-question';
 
 export { TextQuestionOptions } from './interfaces/text-question-options';
 export { CheckBoxQuestion } from './checkbox.model';
+export { RadioButtonQuestion } from './radio-button.model';

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -41,7 +41,7 @@ export class QuestionBase implements BaseOptions {
   calculateExpression?: string;
   componentConfigs: Array<any>;
   options?: any;
-  isOptionUnselectable?: boolean;
+  allowRadioUnselect?: boolean;
 
   constructor(options: BaseOptions) {
     this.defaultValue = options.defaultValue;
@@ -58,7 +58,7 @@ export class QuestionBase implements BaseOptions {
     this.alert = options.alert;
     this.historicalDataValue = options.historicalDataValue;
     this.calculateExpression = options.calculateExpression;
-    this.isOptionUnselectable = options.isOptionUnselectable;
+    this.allowRadioUnselect = options.allowRadioUnselect;
   }
 
   setHistoricalValue(v: boolean) {

--- a/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/question-base.ts
@@ -41,6 +41,7 @@ export class QuestionBase implements BaseOptions {
   calculateExpression?: string;
   componentConfigs: Array<any>;
   options?: any;
+  isOptionUnselectable?: boolean;
 
   constructor(options: BaseOptions) {
     this.defaultValue = options.defaultValue;
@@ -57,6 +58,7 @@ export class QuestionBase implements BaseOptions {
     this.alert = options.alert;
     this.historicalDataValue = options.historicalDataValue;
     this.calculateExpression = options.calculateExpression;
+    this.isOptionUnselectable = options.isOptionUnselectable;
   }
 
   setHistoricalValue(v: boolean) {

--- a/projects/ngx-formentry/src/form-entry/question-models/radio-button.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/radio-button.model.ts
@@ -8,7 +8,7 @@ export class RadioButtonQuestion extends QuestionBase {
   constructor(options: RadioButtonOptions) {
     super(options);
     this.renderingType = 'radio';
-    this.isOptionUnselectable = options.isOptionUnselectable === false;
+    this.allowRadioUnselect = options.allowRadioUnselect === false;
     this.options = options.options || [];
     this.controlType = AfeControlType.AfeFormControl;
   }

--- a/projects/ngx-formentry/src/form-entry/question-models/radio-button.model.ts
+++ b/projects/ngx-formentry/src/form-entry/question-models/radio-button.model.ts
@@ -1,13 +1,14 @@
 import { QuestionBase } from './question-base';
-import { CheckboxOptions } from './interfaces/checkbox-options';
+import { RadioButtonOptions } from './interfaces/radio-button-options';
 import { AfeControlType } from '../../abstract-controls-extension/afe-control-type';
 
-export class CheckBoxQuestion extends QuestionBase {
+export class RadioButtonQuestion extends QuestionBase {
   options: { key: string; value: string }[];
 
-  constructor(options: CheckboxOptions) {
+  constructor(options: RadioButtonOptions) {
     super(options);
-    this.renderingType = 'checkbox';
+    this.renderingType = 'radio';
+    this.isOptionUnselectable = options.isOptionUnselectable === false;
     this.options = options.options || [];
     this.controlType = AfeControlType.AfeFormControl;
   }


### PR DESCRIPTION
Improvement done:  
- Radio buttons are now unelectable 
- This is an optional setting 
- Radio buttons cannot be unselected by default


